### PR TITLE
Refactor: Extract event handling and adapter models into separate modules

### DIFF
--- a/custom_components/power_insight/__init__.py
+++ b/custom_components/power_insight/__init__.py
@@ -12,9 +12,9 @@ from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import DOMAIN, PLATFORMS
 from .utils import state_to_value
-from .power_insight import (
-    DEVICE_ADAPTERS, PowerInsight, EventHandler,
-)
+from .power_insight import PowerInsight
+from .event_handler import EventHandler
+from .adapter_models import ADAPTER_MODELS
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,37 +33,20 @@ class MyData:
 
 async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
     """Init the Mygrid instance from the config entry."""
-    #grid_adapter_data = entry.data["adapter"].copy()
-    #grid_adapter = DEVICE_ADAPTERS["grid"]
-
-    # power_insight = PowerInsight(
-    #     grid_adapter.from_entry(
-    #         unique_id=entry.entry_id,
-    #         name="Grid",
-    #         config=grid_adapter_data["config"],
-    #     )
-    # )
-
     power_insight = PowerInsight()
 
     for subentry in entry.subentries.values():
-        adapter_data = subentry.data["adapter"].copy()
-        adapter_type = adapter_data.get("adapter_type")
+        adapter_type = subentry.data["adapter"].get("adapter_type")
         if not adapter_type:
             continue
 
-        adapter_cls = DEVICE_ADAPTERS.get(adapter_type)
-        if adapter_cls is None:
+        model_cls = ADAPTER_MODELS.get(adapter_type)
+        if model_cls is None:
             _LOGGER.warning("Unknown adapter type %r in subentry %s — skipping.", adapter_type, subentry.subentry_id)
             continue
 
-        power_insight.register_adapter(
-            adapter_cls.from_entry(
-                unique_id=subentry.subentry_id,
-                name=subentry.title,
-                config=adapter_data["config"],
-            )
-        )
+        model = model_cls.from_subentry(subentry)
+        power_insight.register_adapter(model.create_adapter())
     
     if power_insight.grid_adapter is None:
         ir.async_create_issue(

--- a/custom_components/power_insight/adapter_models.py
+++ b/custom_components/power_insight/adapter_models.py
@@ -1,0 +1,188 @@
+"""Adapter models for bridging HA config entry data to adapter instances."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .const import (
+    CONF_POWER_ENTITY, CONF_POWER_ENTITY_INVERTED,
+    CONF_ELECTRICITY_PRICE_ENTITY, CONF_CO2_INTENSITY_ENTITY,
+    CONF_INITIAL_LCOE, CONF_INITIAL_CO2_INTENSITY,
+    CONF_INITIAL_LCOS,
+    CONF_EXPORTS_POWER, CONF_EXPORT_COMPENSATION,
+    CONF_CHARGE_FROM_GRID, CONF_CHARGE_FROM_ADAPTERS,
+)
+from .power_insight import (
+    GridAdapter, PvAdapter, BatteryAdapter, ConsumerAdapter,
+)
+
+
+ADAPTER_MODELS: dict[str, type] = {}
+
+
+def register_model(adapter_type: str):
+    """Register an adapter model class for the given adapter type string."""
+    def decorator(cls):
+        ADAPTER_MODELS[adapter_type] = cls
+        return cls
+    return decorator
+
+
+@register_model("grid")
+@dataclass
+class GridAdapterModel:
+    """Model for creating a GridAdapter from config entry data."""
+
+    unique_id: str
+    name: str
+    power_entity: str
+    power_entity_inverted: bool = False
+    price_entity: str | None = None
+    co2_entity: str | None = None
+
+    @classmethod
+    def from_subentry(cls, subentry) -> GridAdapterModel:
+        """Create model from a config subentry."""
+        config = subentry.data["adapter"]["config"]
+        return cls(
+            unique_id=subentry.subentry_id,
+            name=subentry.title,
+            power_entity=config[CONF_POWER_ENTITY],
+            power_entity_inverted=config.get(CONF_POWER_ENTITY_INVERTED, False),
+            price_entity=config.get(CONF_ELECTRICITY_PRICE_ENTITY),
+            co2_entity=config.get(CONF_CO2_INTENSITY_ENTITY),
+        )
+
+    def create_adapter(self) -> GridAdapter:
+        """Create a GridAdapter instance."""
+        return GridAdapter(
+            unique_id=self.unique_id,
+            verbose_name=self.name,
+            power_entity=self.power_entity,
+            power_entity_inverted=self.power_entity_inverted,
+            price_entity=self.price_entity,
+            co2_entity=self.co2_entity,
+        )
+
+
+@register_model("pv_system")
+@dataclass
+class PvAdapterModel:
+    """Model for creating a PvAdapter from config entry data."""
+
+    unique_id: str
+    name: str
+    power_entity: str
+    power_entity_inverted: bool
+    lcoe: float
+    lco2_intensity: float
+    exports_power: bool
+    export_compensation: float
+
+    @classmethod
+    def from_subentry(cls, subentry) -> PvAdapterModel:
+        """Create model from a config subentry."""
+        config = subentry.data["adapter"]["config"]
+        return cls(
+            unique_id=subentry.subentry_id,
+            name=subentry.title,
+            power_entity=config[CONF_POWER_ENTITY],
+            power_entity_inverted=config[CONF_POWER_ENTITY_INVERTED],
+            lcoe=config[CONF_INITIAL_LCOE],
+            lco2_intensity=config[CONF_INITIAL_CO2_INTENSITY],
+            exports_power=config[CONF_EXPORTS_POWER],
+            export_compensation=config[CONF_EXPORT_COMPENSATION],
+        )
+
+    def create_adapter(self) -> PvAdapter:
+        """Create a PvAdapter instance."""
+        return PvAdapter(
+            unique_id=self.unique_id,
+            verbose_name=self.name,
+            power_entity=self.power_entity,
+            power_entity_inverted=self.power_entity_inverted,
+            lcoe=self.lcoe,
+            lco2_intensity=self.lco2_intensity,
+            exports_power=self.exports_power,
+            export_compensation=self.export_compensation,
+        )
+
+
+@register_model("battery")
+@dataclass
+class BatteryAdapterModel:
+    """Model for creating a BatteryAdapter from config entry data."""
+
+    unique_id: str
+    name: str
+    power_entity: str
+    power_entity_inverted: bool
+    lcos: float
+    lco2_intensity: float
+    exports_power: bool
+    export_compensation: float
+    charge_from_grid: bool = True
+    charge_from_adapters: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_subentry(cls, subentry) -> BatteryAdapterModel:
+        """Create model from a config subentry."""
+        config = subentry.data["adapter"]["config"]
+        return cls(
+            unique_id=subentry.subentry_id,
+            name=subentry.title,
+            power_entity=config[CONF_POWER_ENTITY],
+            power_entity_inverted=config[CONF_POWER_ENTITY_INVERTED],
+            lcos=config[CONF_INITIAL_LCOS],
+            lco2_intensity=config[CONF_INITIAL_CO2_INTENSITY],
+            exports_power=config[CONF_EXPORTS_POWER],
+            export_compensation=config[CONF_EXPORT_COMPENSATION],
+            charge_from_grid=config.get(CONF_CHARGE_FROM_GRID, True),
+            charge_from_adapters=config.get(CONF_CHARGE_FROM_ADAPTERS, []),
+        )
+
+    def create_adapter(self) -> BatteryAdapter:
+        """Create a BatteryAdapter instance."""
+        return BatteryAdapter(
+            unique_id=self.unique_id,
+            verbose_name=self.name,
+            power_entity=self.power_entity,
+            power_entity_inverted=self.power_entity_inverted,
+            lcos=self.lcos,
+            lco2_intensity=self.lco2_intensity,
+            exports_power=self.exports_power,
+            export_compensation=self.export_compensation,
+            charge_from_grid=self.charge_from_grid,
+            charge_from_adapters=self.charge_from_adapters,
+        )
+
+
+@register_model("consumer")
+@dataclass
+class ConsumerAdapterModel:
+    """Model for creating a ConsumerAdapter from config entry data."""
+
+    unique_id: str
+    name: str
+    power_entity: str
+    power_entity_inverted: bool = False
+
+    @classmethod
+    def from_subentry(cls, subentry) -> ConsumerAdapterModel:
+        """Create model from a config subentry."""
+        config = subentry.data["adapter"]["config"]
+        return cls(
+            unique_id=subentry.subentry_id,
+            name=subentry.title,
+            power_entity=config[CONF_POWER_ENTITY],
+            power_entity_inverted=config[CONF_POWER_ENTITY_INVERTED],
+        )
+
+    def create_adapter(self) -> ConsumerAdapter:
+        """Create a ConsumerAdapter instance."""
+        return ConsumerAdapter(
+            unique_id=self.unique_id,
+            verbose_name=self.name,
+            power_entity=self.power_entity,
+            power_entity_inverted=self.power_entity_inverted,
+        )

--- a/custom_components/power_insight/event_handler.py
+++ b/custom_components/power_insight/event_handler.py
@@ -1,0 +1,169 @@
+"""Event handler for the PowerInsight integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from homeassistant.const import (
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    EVENT_STATE_CHANGED,
+    EVENT_STATE_REPORTED,
+)
+
+from homeassistant.core import (
+    Event,
+    EventStateChangedData,
+    EventStateReportedData,
+    State,
+    callback,
+)
+
+from homeassistant.helpers.event import (
+    async_track_state_change_event,
+)
+
+from .const import DOMAIN
+from .power_insight import UNIT_PREFIXES
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EventHandler:
+    """Handle the communication between power_insight and the event bus."""
+
+    def __init__(self, hass, entry_id, power_insight) -> None:
+        self.hass = hass
+        self.power_insight = power_insight
+
+        self._event_prefix = f"{DOMAIN}_{entry_id}_"
+
+        self._unsub_state_change_listener = []
+
+
+    def track_entities(self, entity_ids: Iterable[str]) -> None:
+
+        handle_state_change = self._update_on_state_change_callback
+        handle_state_report = self._update_on_state_report_callback
+
+        unsub = (
+            async_track_state_change_event(
+                self.hass,
+                entity_ids,
+                handle_state_change,
+            ),
+            async_track_state_change_event(
+                self.hass,
+                entity_ids,
+                handle_state_report,
+            ),
+        )
+        self._unsub_state_change_listener.extend(unsub)
+
+    def untrack_entities(self) -> None:
+        for unsub in self._unsub_state_change_listener:
+            unsub()
+
+
+    @callback
+    def _update_on_state_change_callback(
+        self, event: Event[EventStateChangedData]
+    ) -> None:
+        """Handle sensor state change."""
+        return self._update_on_state_change(
+            event.data,
+            event.data["entity_id"],
+            event.data["old_state"],
+            event.data["new_state"],
+            None,
+        )
+
+    @callback
+    def _update_on_state_report_callback(
+        self, event: Event[EventStateReportedData]
+    ) -> None:
+        """Handle sensor state report."""
+        return self._update_on_state_change(
+            event.data,
+            event.data["entity_id"],
+            None,
+            None,
+            event.data["new_state"],
+        )
+
+    def _update_on_state_change(
+        self,
+        event_data: EventStateChangedData | EventStateReportedData,
+        entity_id: str,
+        old_state: State | None,
+        new_state: State | None,
+        curr_state: State | None,
+        # old_timestamp: datetime | None,
+        # new_timestamp: datetime | None,
+    ) -> None:
+        """Update the data on state change.
+
+        Ref: https://www.home-assistant.io/docs/configuration/events/#state_changed  #noqa
+
+        """
+        INVALID_STATES = (STATE_UNAVAILABLE, STATE_UNKNOWN)
+
+        if curr_state:
+            new_state = curr_state
+
+        # Entity was removed from Home Assistant.
+        if new_state is None:
+            value = None
+
+        # Entity does not provide valid data.
+        elif new_state.state in INVALID_STATES:
+
+            # The old state was a valid value.
+            if old_state and old_state not in INVALID_STATES:
+                # TODO: implement a short keep alive period for the value.
+                # cancel = self._schedule_freeze_cancellation(
+                #     self._keep_alive, entity_id, None
+                # )
+                # self.async_on_remove(cancel)
+                # self._freeze_callbacks[entity_id] = cancel
+                value = None
+            else:
+                value = None
+
+        # We expect a valid state value
+        else:
+            value = self._state_to_value(new_state)
+
+
+        # Unfreeze the value as soon we have a new valid value.
+        # https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/entity.py LN 1332  # noqa
+        # if value and entity_id in self._freeze_callbacks:
+        #     cancel = self._freeze_callbacks.pop(entity_id)
+        #     cancel()
+
+        # Set the value of the entity in power_insight.
+        self.power_insight.set_value(entity_id, value)
+
+        # Fire an event to notify all entities that depend on this entity_id.
+        # We send a custom event to ensure that the instance is updated
+        # before the entities retrieve the signal to update.
+        if curr_state is not None:
+            event_type = self._event_prefix + EVENT_STATE_REPORTED
+        else:
+            event_type = self._event_prefix + EVENT_STATE_CHANGED
+
+        self.hass.bus.async_fire(event_type, event_data)
+
+    def _state_to_value(self, state_obj: State) -> float | None:
+        """Return the state of the given state object as float."""
+        try:
+            value = float(state_obj.state)
+        except ValueError:
+            return None
+
+        if unit := state_obj.attributes.get("unit_of_measurement"):
+            unit = unit[0]
+
+        return value * UNIT_PREFIXES.get(unit, 1.0)

--- a/custom_components/power_insight/power_insight.py
+++ b/custom_components/power_insight/power_insight.py
@@ -4,56 +4,11 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Iterable
-
-
-from homeassistant.const import (
-    CONF_NAME,
-    STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
-    EVENT_STATE_CHANGED,
-    EVENT_STATE_REPORTED,
-)
-
-from homeassistant.core import (
-    Event,
-    EventStateChangedData,
-    EventStateReportedData,
-    State,
-    callback,
-)
-
-from homeassistant.helpers.event import (
-    async_track_state_change_event,
-)
-
-from .const import (
-    DOMAIN,
-    CONF_KEY,
-    CONF_POWER_ENTITY, CONF_POWER_ENTITY_INVERTED,
-    CONF_ELECTRICITY_PRICE_ENTITY, CONF_CO2_INTENSITY_ENTITY,
-    CONF_INITIAL_LCOE, CONF_INITIAL_CO2_INTENSITY,
-    CONF_INITIAL_LCOS,
-    CONF_EXPORTS_POWER, CONF_EXPORT_COMPENSATION,
-    CONF_CHARGE_FROM_GRID, CONF_CHARGE_FROM_ADAPTERS,
-)
-
-from .exceptions import create_hass_exception
 
 
 _LOGGER = logging.getLogger(__name__)
 
 UNIT_PREFIXES = {None: 1, "k": 10**3, "M": 10**6, "G": 10**9, "T": 10**12}
-
-DEVICE_ADAPTERS = {}
-
-
-def register_adapter(adapter: AbstractBaseAdapter) -> AbstractBaseAdapter:
-    """Register the given StorageRule class."""
-    for adapter_type in adapter.ADAPTER_TYPES:
-        DEVICE_ADAPTERS[adapter_type] = adapter
-
-    return adapter
 
 
 class AdapterContainer:
@@ -337,7 +292,7 @@ class PowerInsight:
             return None
 
         if grid_export and not total_power:
-            create_hass_exception(ValueError("Data discrepancy."))
+            _LOGGER.warning("Data discrepancy: grid export without total power.")
 
         return self._divide(grid_export, total_power)
 
@@ -351,7 +306,7 @@ class PowerInsight:
             return None
 
         if utilization_power and not total_power:
-            create_hass_exception(ValueError("Mising device."))
+            _LOGGER.warning("Data discrepancy: utilization without total power.")
 
         return self._divide(utilization_power, total_power)
 
@@ -365,7 +320,7 @@ class PowerInsight:
             return None
 
         if self_consumption and not total_power:
-            create_hass_exception(ValueError("Mising device."))
+            _LOGGER.warning("Data discrepancy: self-consumption without total power.")
 
         return self._divide(self_consumption, total_power)
 
@@ -1075,148 +1030,6 @@ class PowerInsight:
 
 
 
-class EventHandler:
-    """Handle the communication between power_insight and the event bus."""
-
-    def __init__(self, hass, entry_id, power_insight) -> None:
-        self.hass = hass
-        self.power_insight = power_insight
-
-        self._event_prefix = f"{DOMAIN}_{entry_id}_"
-
-        self._unsub_state_change_listener = []
-
-
-    def track_entities(self, entity_ids: Iterable[str]) -> None:
-
-        handle_state_change = self._update_on_state_change_callback
-        handle_state_report = self._update_on_state_report_callback
-
-        unsub = (
-            async_track_state_change_event(
-                self.hass,
-                entity_ids,
-                handle_state_change,
-            ),
-            async_track_state_change_event(
-                self.hass,
-                entity_ids,
-                handle_state_report,
-            ),
-        )
-        self._unsub_state_change_listener.extend(unsub)
-
-    def untrack_entities(self) -> None:
-        for unsub in self._unsub_state_change_listener:
-            unsub()
-
-
-    @callback
-    def _update_on_state_change_callback(
-        self, event: Event[EventStateChangedData]
-    ) -> None:
-        """Handle sensor state change."""
-        return self._update_on_state_change(
-            event.data,
-            event.data["entity_id"],
-            event.data["old_state"],
-            event.data["new_state"],
-            None,
-        )
-
-    @callback
-    def _update_on_state_report_callback(
-        self, event: Event[EventStateReportedData]
-    ) -> None:
-        """Handle sensor state report."""
-        return self._update_on_state_change(
-            event.data,
-            event.data["entity_id"],
-            None,
-            None,
-            event.data["new_state"],
-        )
-
-    def _update_on_state_change(
-        self,
-        event_data: EventStateChangedData | EventStateReportedData,
-        entity_id: str,
-        old_state: State | None,
-        new_state: State | None,
-        curr_state: State | None,
-        # old_timestamp: datetime | None,
-        # new_timestamp: datetime | None,
-    ) -> None:
-        """Update the data on state change.
-
-        Ref: https://www.home-assistant.io/docs/configuration/events/#state_changed  #noqa
-
-        """
-        INVALID_STATES = (STATE_UNAVAILABLE, STATE_UNKNOWN)
-
-        if curr_state:
-            new_state = curr_state
-
-        # Entity was removed from Home Assistant.
-        if new_state is None:
-            value = None
-
-        # Entity does not provide valid data.
-        elif new_state.state in INVALID_STATES:
-
-            # The old state was a valid value.
-            if old_state and old_state not in INVALID_STATES:
-                # TODO: implement a short keep alive period for the value.
-                # cancel = self._schedule_freeze_cancellation(
-                #     self._keep_alive, entity_id, None
-                # )
-                # self.async_on_remove(cancel)
-                # self._freeze_callbacks[entity_id] = cancel
-                value = None
-            else:
-                value = None
-
-        # We expect a valid state value
-        else:
-            value = self._state_to_value(new_state)
-
-
-        # Unfreeze the value as soon we have a new valid value.
-        # https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/entity.py LN 1332  # noqa
-        # if value and entity_id in self._freeze_callbacks:
-        #     cancel = self._freeze_callbacks.pop(entity_id)
-        #     cancel()
-
-        # Set the value of the entity in power_insight.
-        self.power_insight.set_value(entity_id, value)
-
-        # Fire an event to notify all entities that depend on this entity_id.
-        # We send a custom event to ensure that the instance is updated
-        # before the entities retrieve the signal to update.
-        if curr_state is not None:
-            event_type = self._event_prefix + EVENT_STATE_REPORTED
-        else:
-            event_type = self._event_prefix + EVENT_STATE_CHANGED
-
-        self.hass.bus.async_fire(event_type, event_data)
-
-    def _state_to_value(self, state_obj: State) -> float | None:
-        """Return the state of the given state object as float."""
-        try:
-            value = float(state_obj.state)
-        except ValueError:
-            return None
-
-        if unit := state_obj.attributes.get("unit_of_measurement"):
-            unit = unit[0]
-
-        return value * UNIT_PREFIXES.get(unit, 1.0)
-
-
-
-
-
-
 
 class AbstractBaseAdapter(ABC):
     """Abstract base adapter."""
@@ -1257,12 +1070,6 @@ class AbstractBaseAdapter(ABC):
     def set_value(self, entity_id, value) -> None:
         """Set the value for an entity."""
         self._values[entity_id] = value
-
-    @classmethod
-    @abstractmethod
-    def from_entry(cls, *args, **kwargs) -> BasePowerAdapter:
-        """Initialize instance from a config entry."""
-        pass
 
 
 class BasePowerAdapter(AbstractBaseAdapter):
@@ -1329,7 +1136,6 @@ class BasePowerProvidingAdapter(BasePowerAdapter):
         pass
 
 
-@register_adapter
 class GridAdapter(BasePowerProvidingAdapter):
     """Grid power adapter."""
 
@@ -1447,19 +1253,6 @@ class GridAdapter(BasePowerProvidingAdapter):
     def lco2_intensity_rate(self) -> float | None:
         """Return the levelized co2 intensity rate in g/h."""
         pass
-
-    @classmethod
-    def from_entry(cls, unique_id: str, name: str, config: dict) -> GridAdapter:
-        """Create instance from config."""
-        return cls(
-            unique_id=unique_id,
-            verbose_name=name,
-            power_entity=config[CONF_POWER_ENTITY],
-            power_entity_inverted=config.get(CONF_POWER_ENTITY_INVERTED),
-            price_entity=config.get(CONF_ELECTRICITY_PRICE_ENTITY),
-            co2_entity=config.get(CONF_CO2_INTENSITY_ENTITY),
-        )
-
 
 class BaseProductionAdapter(BasePowerProvidingAdapter):
     """Grid power adapter."""
@@ -1606,7 +1399,6 @@ class BaseProductionAdapter(BasePowerProvidingAdapter):
         return (cons / 1000) * value
 
 
-@register_adapter
 class PvAdapter(BaseProductionAdapter):
     """Photovoltaic system adapter."""
 
@@ -1642,22 +1434,6 @@ class PvAdapter(BaseProductionAdapter):
         """Return the levelized cost of electicity in Euro/kwh."""
         return self._lcoe
 
-    @classmethod
-    def from_entry(cls, unique_id: str, name: str, config: dict) -> PvAdapter:
-        """Create instance from config."""
-        return cls(
-            unique_id=unique_id,
-            verbose_name=name,
-            power_entity=config[CONF_POWER_ENTITY],
-            power_entity_inverted=config[CONF_POWER_ENTITY_INVERTED],
-            lcoe=config[CONF_INITIAL_LCOE],
-            lco2_intensity=config[CONF_INITIAL_CO2_INTENSITY],
-            exports_power=config[CONF_EXPORTS_POWER],
-            export_compensation=config[CONF_EXPORT_COMPENSATION],
-        )
-
-
-@register_adapter
 class BatteryAdapter(BaseProductionAdapter):
     """Battery adapter."""
 
@@ -1699,24 +1475,6 @@ class BatteryAdapter(BaseProductionAdapter):
     def lcoe(self) -> float | None:
         """Return the levelized cost of electicity in Euro/kwh."""
         return self._lcos
-
-    @classmethod
-    def from_entry(cls, unique_id: str, name: str, config: dict) -> BatteryAdapter:
-        """Create instance from config."""
-        return cls(
-            unique_id=unique_id,
-            verbose_name=name,
-            power_entity=config[CONF_POWER_ENTITY],
-            power_entity_inverted=config[CONF_POWER_ENTITY_INVERTED],
-            lcos=config[CONF_INITIAL_LCOS],
-            lco2_intensity=config[CONF_INITIAL_CO2_INTENSITY],
-            exports_power=config[CONF_EXPORTS_POWER],
-            export_compensation=config[CONF_EXPORT_COMPENSATION],
-            charge_from_grid=config.get(CONF_CHARGE_FROM_GRID, True),
-            charge_from_adapters=config.get(CONF_CHARGE_FROM_ADAPTERS),
-        )
-        # TODO: add CONF_BAT_EFFICIENCY
-
 
 class BaseConsumerAdapter(BasePowerAdapter):
     """Base adapter for consumers."""
@@ -1761,17 +1519,6 @@ class BaseConsumerAdapter(BasePowerAdapter):
         return (cons / 1000) * value
 
 
-@register_adapter
 class ConsumerAdapter(BaseConsumerAdapter):
 
-    ADAPTER_TYPES = ("consumer",)
-
-    @classmethod
-    def from_entry(cls, unique_id: str, name: str, config: dict) -> ConsumerAdapter:
-        """Create instance from config."""
-        return cls(
-            unique_id=unique_id,
-            verbose_name=name,
-            power_entity=config[CONF_POWER_ENTITY],
-            power_entity_inverted=config[CONF_POWER_ENTITY_INVERTED],
-        )
+    pass

--- a/tests/test_power_calculations.py
+++ b/tests/test_power_calculations.py
@@ -1,0 +1,698 @@
+"""Tests for PowerInsight core calculation logic.
+
+Three scenarios of increasing complexity:
+  1. Grid + PV  (excess production → exporting)
+  2. Grid + PV + Battery  (all consumed, no export)
+  3. Grid + PV + Battery + Consumer  (consumer cost allocation)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+# Import power_insight.py directly (bypassing the package __init__.py
+# which depends on Home Assistant).
+_MODULE_PATH = os.path.join(
+    os.path.dirname(__file__),
+    os.pardir,
+    "custom_components",
+    "power_insight",
+    "power_insight.py",
+)
+_spec = importlib.util.spec_from_file_location("power_insight", _MODULE_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+PowerInsight = _mod.PowerInsight
+GridAdapter = _mod.GridAdapter
+PvAdapter = _mod.PvAdapter
+BatteryAdapter = _mod.BatteryAdapter
+ConsumerAdapter = _mod.ConsumerAdapter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def build_power_insight(adapters, values):
+    """Create a PowerInsight instance, register adapters, and set values."""
+    pi = PowerInsight()
+    for adapter in adapters:
+        pi.register_adapter(adapter)
+    for entity_id, value in values.items():
+        pi.set_value(entity_id, value)
+    return pi
+
+
+# ---------------------------------------------------------------------------
+# Scenario definitions
+# ---------------------------------------------------------------------------
+
+# Entity IDs (arbitrary strings – only need to be consistent)
+GRID_POWER = "sensor.grid_power"
+GRID_PRICE = "sensor.grid_price"
+PV_POWER = "sensor.pv_power"
+BAT_POWER = "sensor.bat_power"
+CONS_POWER = "sensor.consumer_power"
+
+# Config constants
+GRID_PRICE_VALUE = 0.30   # EUR/kWh
+PV_LCOE = 0.08            # EUR/kWh
+PV_EXPORT_COMP = 0.08     # EUR/kWh
+BAT_LCOS = 0.12           # EUR/kWh
+
+
+def _make_grid(power_value, price_value=GRID_PRICE_VALUE):
+    adapter = GridAdapter(
+        unique_id="grid",
+        verbose_name="Grid",
+        power_entity=GRID_POWER,
+        price_entity=GRID_PRICE,
+    )
+    return adapter, {GRID_POWER: power_value, GRID_PRICE: price_value}
+
+
+def _make_pv(power_value, lcoe=PV_LCOE, exports=True, compensation=PV_EXPORT_COMP):
+    adapter = PvAdapter(
+        unique_id="pv",
+        verbose_name="PV",
+        power_entity=PV_POWER,
+        power_entity_inverted=False,
+        lcoe=lcoe,
+        lco2_intensity=0.0,
+        exports_power=exports,
+        export_compensation=compensation,
+    )
+    return adapter, {PV_POWER: power_value}
+
+
+def _make_battery(power_value, lcos=BAT_LCOS, exports=False, compensation=0.0):
+    adapter = BatteryAdapter(
+        unique_id="bat",
+        verbose_name="Battery",
+        power_entity=BAT_POWER,
+        power_entity_inverted=False,
+        lcos=lcos,
+        lco2_intensity=0.0,
+        exports_power=exports,
+        export_compensation=compensation,
+    )
+    return adapter, {BAT_POWER: power_value}
+
+
+def _make_consumer(power_value):
+    adapter = ConsumerAdapter(
+        unique_id="cons",
+        verbose_name="Consumer",
+        power_entity=CONS_POWER,
+    )
+    return adapter, {CONS_POWER: power_value}
+
+
+def _build_scenario(adapter_specs):
+    """Build PowerInsight from a list of (adapter, values_dict) tuples."""
+    adapters = []
+    values = {}
+    for adapter, vals in adapter_specs:
+        adapters.append(adapter)
+        values.update(vals)
+    return build_power_insight(adapters, values)
+
+
+# ===================================================================
+# Scenario 1 — Grid + PV  (PV overproducing → exporting to grid)
+# ===================================================================
+# Grid power: -1000 W  (negative = exporting)
+# PV power:    3000 W  (producing)
+# Grid price:  0.30 EUR/kWh
+# PV LCOE:     0.08 EUR/kWh
+# PV exports:  True, compensation = 0.08 EUR/kWh
+# ===================================================================
+
+class TestScenario1GridPv:
+    """Grid + PV with excess production (exporting)."""
+
+    @pytest.fixture()
+    def pi(self):
+        return _build_scenario([
+            _make_grid(-1000),
+            _make_pv(3000),
+        ])
+
+    # -- Power flows --
+
+    def test_grid_import(self, pi):
+        # grid power = -1000 → import = max(power, 0) = 0
+        assert pi.grid_import == pytest.approx(0.0)
+
+    def test_grid_export(self, pi):
+        # grid power = -1000 → export = -power = 1000
+        assert pi.grid_export == pytest.approx(1000.0)
+
+    def test_production(self, pi):
+        # PV produces 3000
+        assert pi.production == pytest.approx(3000.0)
+
+    def test_utilization(self, pi):
+        # PV consumption = max(-power, 0) = 0 (producing, not consuming)
+        assert pi.utilization == pytest.approx(0.0)
+
+    def test_total_power(self, pi):
+        # grid_import + production = 0 + 3000
+        assert pi.total_power == pytest.approx(0 + 3000)
+
+    def test_self_consumption(self, pi):
+        # total_power - grid_export - utilization = 3000 - 1000 - 0
+        assert pi.self_consumption == pytest.approx(3000 - 1000 - 0)
+
+    # -- Shares --
+
+    def test_export_share(self, pi):
+        # grid_export / total_power = 1000 / 3000
+        assert pi.export_share == pytest.approx(1000 / 3000)
+
+    def test_utilization_share(self, pi):
+        # utilization / total_power = 0 / 3000
+        assert pi.utilization_share == pytest.approx(0.0)
+
+    def test_self_consumption_share(self, pi):
+        # self_consumption / total_power = 2000 / 3000
+        assert pi.self_consumption_share == pytest.approx(2000 / 3000)
+
+    def test_applicable_utilization_share(self, pi):
+        # utilization_share / (1 - export_share) = 0 / (1 - 1/3)
+        assert pi.applicable_utilization_share == pytest.approx(0.0)
+
+    def test_applicable_self_consumption_share(self, pi):
+        # self_cons_share / (1 - export_share) = (2/3) / (2/3) = 1.0
+        assert pi.applicable_self_consumption_share == pytest.approx(
+            (2000 / 3000) / (1 - 1000 / 3000)
+        )
+
+    # -- Cost rates --
+
+    def test_coe_rate(self, pi):
+        # grid_coe_rate + pv_coe_rate
+        # grid: import=0 → coe_rate=0
+        # pv: coe=0.0 (base prod adapter) → coe_rate = (3000/1000)*0 = 0
+        assert pi.coe_rate == pytest.approx(0.0)
+
+    def test_coe(self, pi):
+        # coe_rate / total_power_kW = 0 / 3 = 0
+        assert pi.coe == pytest.approx(0.0)
+
+    def test_lcoe_rate(self, pi):
+        # grid: import=0 → lcoe_rate=0
+        # pv: lcoe=0.08 → lcoe_rate = (3000/1000) * 0.08 = 0.24
+        assert pi.lcoe_rate == pytest.approx(0 + (3000 / 1000) * PV_LCOE)
+
+    def test_lcoe(self, pi):
+        # lcoe_rate / total_power_kW = 0.24 / 3.0
+        lcoe_rate = (3000 / 1000) * PV_LCOE
+        assert pi.lcoe == pytest.approx(lcoe_rate / (3000 / 1000))
+
+    # -- Grid adapter properties --
+
+    def test_grid_adapter_total_power_shares(self, pi):
+        # grid_import / total_power = 0 / 3000
+        assert pi.grid_adapter_total_power_shares["grid"] == pytest.approx(0.0)
+
+    def test_grid_adapter_self_cons_rates(self, pi):
+        # applicable_self_consumption_share (same for all providers)
+        assert pi.grid_adapter_self_cons_rates["grid"] == pytest.approx(
+            (2000 / 3000) / (1 - 1000 / 3000)
+        )
+
+    def test_grid_adapter_self_cons_shares(self, pi):
+        # (self_cons_rate * power_share) / self_cons_share
+        # = (1.0 * 0.0) / (2/3) = 0
+        assert pi.grid_adapter_self_cons_shares["grid"] == pytest.approx(0.0)
+
+    # -- Production adapter properties --
+
+    def test_prod_adapters_total_power_shares(self, pi):
+        # pv production / total_power = 3000 / 3000
+        assert pi.prod_adapters_total_power_shares["pv"] == pytest.approx(
+            3000 / 3000
+        )
+
+    def test_prod_adapters_export_shares(self, pi):
+        # PV is the only exporter → 100%
+        assert pi.prod_adapters_export_shares["pv"] == pytest.approx(1.0)
+
+    def test_prod_adapters_export_rates(self, pi):
+        # export_share_pv * total_export_share / power_share_pv
+        # = 1.0 * (1/3) / 1.0 = 1/3
+        assert pi.prod_adapters_export_rates["pv"] == pytest.approx(
+            1.0 * (1000 / 3000) / (3000 / 3000)
+        )
+
+    def test_prod_adapters_export_power(self, pi):
+        # grid_export * export_share = 1000 * 1.0
+        assert pi.prod_adapters_export_power["pv"] == pytest.approx(
+            1000 * 1.0
+        )
+
+    def test_prod_adapters_export_compensation_rates(self, pi):
+        # export_power_kW * compensation = (1000/1000) * 0.08
+        assert pi.prod_adapters_export_compensation_rates["pv"] == pytest.approx(
+            (1000 / 1000) * PV_EXPORT_COMP
+        )
+
+    def test_prod_adapters_self_cons_rates(self, pi):
+        # (1 - export_rate) * applicable_self_cons_share
+        # export_rate_pv = 1/3
+        # applicable_self_cons_share = 1.0
+        # = (1 - 1/3) * 1.0 = 2/3
+        export_rate_pv = 1.0 * (1000 / 3000) / (3000 / 3000)
+        applicable = (2000 / 3000) / (1 - 1000 / 3000)
+        assert pi.prod_adapters_self_cons_rates["pv"] == pytest.approx(
+            (1 - export_rate_pv) * applicable
+        )
+
+    def test_prod_adapters_self_cons_power(self, pi):
+        # production * self_cons_rate = 3000 * 2/3
+        export_rate_pv = 1.0 * (1000 / 3000) / (3000 / 3000)
+        applicable = (2000 / 3000) / (1 - 1000 / 3000)
+        self_cons_rate = (1 - export_rate_pv) * applicable
+        assert pi.prod_adapters_self_cons_power["pv"] == pytest.approx(
+            3000 * self_cons_rate
+        )
+
+    def test_prod_adapters_self_cons_saving_rates(self, pi):
+        # self_cons_power_kW * grid_coe
+        # grid_coe = 0.30 (price entity value)
+        export_rate_pv = 1.0 * (1000 / 3000) / (3000 / 3000)
+        applicable = (2000 / 3000) / (1 - 1000 / 3000)
+        self_cons_rate = (1 - export_rate_pv) * applicable
+        self_cons_power = 3000 * self_cons_rate
+        assert pi.prod_adapters_self_cons_saving_rates["pv"] == pytest.approx(
+            (self_cons_power / 1000) * GRID_PRICE_VALUE
+        )
+
+    def test_prod_adapters_coo_rates(self, pi):
+        # consumption_kW * coe (blended)
+        # PV consumption = 0, so coo_rate = 0
+        assert pi.prod_adapters_coo_rates["pv"] == pytest.approx(0.0)
+
+    def test_prod_adapters_lcoo_rates(self, pi):
+        # consumption_kW * lcoe (blended)
+        # PV consumption = 0, so lcoo_rate = 0
+        assert pi.prod_adapters_lcoo_rates["pv"] == pytest.approx(0.0)
+
+    def test_prod_adapters_saving_rates(self, pi):
+        # export_compensation + self_cons_savings - coo_rate - coe_rate
+        # coe_rate for PV = (3000/1000) * 0.0 = 0 (BaseProductionAdapter.coe = 0)
+        export_comp = (1000 / 1000) * PV_EXPORT_COMP
+        export_rate_pv = 1.0 * (1000 / 3000) / (3000 / 3000)
+        applicable = (2000 / 3000) / (1 - 1000 / 3000)
+        self_cons_rate = (1 - export_rate_pv) * applicable
+        self_cons_power = 3000 * self_cons_rate
+        self_cons_savings = (self_cons_power / 1000) * GRID_PRICE_VALUE
+        coo_rate = 0.0  # PV consumption = 0
+        coe_rate = 0.0  # BaseProductionAdapter.coe = 0
+        assert pi.prod_adapters_saving_rates["pv"] == pytest.approx(
+            export_comp + self_cons_savings - coo_rate - coe_rate
+        )
+
+    def test_prod_adapters_levelized_saving_rates(self, pi):
+        # Same as saving_rates but uses lcoe_rate and lcoo_rate
+        export_comp = (1000 / 1000) * PV_EXPORT_COMP
+        export_rate_pv = 1.0 * (1000 / 3000) / (3000 / 3000)
+        applicable = (2000 / 3000) / (1 - 1000 / 3000)
+        self_cons_rate = (1 - export_rate_pv) * applicable
+        self_cons_power = 3000 * self_cons_rate
+        self_cons_savings = (self_cons_power / 1000) * GRID_PRICE_VALUE
+        lcoo_rate = 0.0  # PV consumption = 0
+        lcoe_rate = (3000 / 1000) * PV_LCOE  # PV lcoe_rate
+        assert pi.prod_adapters_levelized_saving_rates["pv"] == pytest.approx(
+            export_comp + self_cons_savings - lcoo_rate - lcoe_rate
+        )
+
+    # -- Totals --
+
+    def test_total_export_compensation_rate(self, pi):
+        assert pi.total_export_compensation_rate == pytest.approx(
+            (1000 / 1000) * PV_EXPORT_COMP
+        )
+
+    def test_total_self_cons_saving_rate(self, pi):
+        export_rate_pv = 1.0 * (1000 / 3000) / (3000 / 3000)
+        applicable = (2000 / 3000) / (1 - 1000 / 3000)
+        self_cons_rate = (1 - export_rate_pv) * applicable
+        self_cons_power = 3000 * self_cons_rate
+        assert pi.total_self_cons_saving_rate == pytest.approx(
+            (self_cons_power / 1000) * GRID_PRICE_VALUE
+        )
+
+    def test_total_coo_rate(self, pi):
+        assert pi.total_coo_rate == pytest.approx(0.0)
+
+    def test_total_saving_rate(self, pi):
+        export_comp = (1000 / 1000) * PV_EXPORT_COMP
+        export_rate_pv = 1.0 * (1000 / 3000) / (3000 / 3000)
+        applicable = (2000 / 3000) / (1 - 1000 / 3000)
+        self_cons_rate = (1 - export_rate_pv) * applicable
+        self_cons_power = 3000 * self_cons_rate
+        self_cons_savings = (self_cons_power / 1000) * GRID_PRICE_VALUE
+        assert pi.total_saving_rate == pytest.approx(
+            export_comp + self_cons_savings - 0 - 0
+        )
+
+
+# ===================================================================
+# Scenario 2 — Grid + PV + Battery  (all consumed, no export)
+# ===================================================================
+# Grid power:  500 W   (importing)
+# PV power:   2000 W   (producing)
+# Bat power:  1000 W   (discharging)
+# Grid price:  0.30 EUR/kWh
+# PV LCOE:     0.08, exports_power=True, compensation=0.08
+# Bat LCOS:    0.12, exports_power=False
+# ===================================================================
+
+class TestScenario2GridPvBattery:
+    """Grid + PV + Battery, all power consumed (no export)."""
+
+    @pytest.fixture()
+    def pi(self):
+        return _build_scenario([
+            _make_grid(500),
+            _make_pv(2000),
+            _make_battery(1000),
+        ])
+
+    # -- Power flows --
+
+    def test_grid_import(self, pi):
+        assert pi.grid_import == pytest.approx(500.0)
+
+    def test_grid_export(self, pi):
+        assert pi.grid_export == pytest.approx(0.0)
+
+    def test_production(self, pi):
+        # PV + Battery = 2000 + 1000
+        assert pi.production == pytest.approx(2000 + 1000)
+
+    def test_utilization(self, pi):
+        # Both PV and battery consumption = 0 (both producing)
+        assert pi.utilization == pytest.approx(0.0)
+
+    def test_total_power(self, pi):
+        # grid_import + production = 500 + 3000
+        assert pi.total_power == pytest.approx(500 + 2000 + 1000)
+
+    def test_self_consumption(self, pi):
+        # total_power - export - utilization = 3500 - 0 - 0
+        assert pi.self_consumption == pytest.approx(3500 - 0 - 0)
+
+    # -- Shares --
+
+    def test_export_share(self, pi):
+        assert pi.export_share == pytest.approx(0.0)
+
+    def test_self_consumption_share(self, pi):
+        # All power is self-consumed
+        assert pi.self_consumption_share == pytest.approx(3500 / 3500)
+
+    def test_applicable_self_consumption_share(self, pi):
+        # self_cons_share / (1 - 0) = 1.0
+        assert pi.applicable_self_consumption_share == pytest.approx(1.0)
+
+    # -- Cost rates --
+
+    def test_coe_rate(self, pi):
+        # grid: (500/1000) * 0.30 = 0.15
+        # pv: (2000/1000) * 0.0 = 0
+        # bat: (1000/1000) * 0.0 = 0
+        assert pi.coe_rate == pytest.approx(
+            (500 / 1000) * GRID_PRICE_VALUE + 0 + 0
+        )
+
+    def test_coe(self, pi):
+        # coe_rate / total_power_kW
+        grid_coe_rate = (500 / 1000) * GRID_PRICE_VALUE
+        assert pi.coe == pytest.approx(grid_coe_rate / (3500 / 1000))
+
+    def test_lcoe_rate(self, pi):
+        # grid: (500/1000) * 0.30
+        # pv: (2000/1000) * 0.08
+        # bat: (1000/1000) * 0.12  (BatteryAdapter.lcoe returns lcos)
+        assert pi.lcoe_rate == pytest.approx(
+            (500 / 1000) * GRID_PRICE_VALUE
+            + (2000 / 1000) * PV_LCOE
+            + (1000 / 1000) * BAT_LCOS
+        )
+
+    def test_lcoe(self, pi):
+        lcoe_rate = (
+            (500 / 1000) * GRID_PRICE_VALUE
+            + (2000 / 1000) * PV_LCOE
+            + (1000 / 1000) * BAT_LCOS
+        )
+        assert pi.lcoe == pytest.approx(lcoe_rate / (3500 / 1000))
+
+    # -- Grid adapter properties --
+
+    def test_grid_adapter_total_power_shares(self, pi):
+        assert pi.grid_adapter_total_power_shares["grid"] == pytest.approx(
+            500 / 3500
+        )
+
+    # -- Production adapter share distribution --
+
+    def test_prod_adapters_total_power_shares(self, pi):
+        assert pi.prod_adapters_total_power_shares["pv"] == pytest.approx(
+            2000 / 3500
+        )
+        assert pi.prod_adapters_total_power_shares["bat"] == pytest.approx(
+            1000 / 3500
+        )
+
+    def test_prod_adapters_export_shares(self, pi):
+        # PV exports_power=True, battery exports_power=False
+        # But export_share=0 (no actual export), so export_shares
+        # are based on power_shares of exporters only
+        # PV is the only exporter → 100%
+        assert pi.prod_adapters_export_shares["pv"] == pytest.approx(1.0)
+        assert pi.prod_adapters_export_shares["bat"] == pytest.approx(0.0)
+
+    def test_prod_adapters_export_rates(self, pi):
+        # export_share_adapter * total_export_share / power_share_adapter
+        # total_export_share = 0, so numerator = 0
+        assert pi.prod_adapters_export_rates["pv"] == pytest.approx(0.0)
+        assert pi.prod_adapters_export_rates["bat"] == pytest.approx(0.0)
+
+    def test_prod_adapters_export_power(self, pi):
+        # grid_export * export_share = 0 * anything
+        assert pi.prod_adapters_export_power["pv"] == pytest.approx(0.0)
+        assert pi.prod_adapters_export_power["bat"] == pytest.approx(0.0)
+
+    def test_prod_adapters_export_compensation_rates(self, pi):
+        assert pi.prod_adapters_export_compensation_rates["pv"] == pytest.approx(0.0)
+        assert pi.prod_adapters_export_compensation_rates["bat"] == pytest.approx(0.0)
+
+    def test_prod_adapters_self_cons_rates(self, pi):
+        # (1 - export_rate) * applicable_self_cons_share
+        # export_rate = 0 for both, applicable = 1.0
+        assert pi.prod_adapters_self_cons_rates["pv"] == pytest.approx(
+            (1 - 0) * 1.0
+        )
+        assert pi.prod_adapters_self_cons_rates["bat"] == pytest.approx(
+            (1 - 0) * 1.0
+        )
+
+    def test_prod_adapters_self_cons_shares(self, pi):
+        # (self_cons_rate * power_share) / self_cons_share
+        # self_cons_rate=1.0 for both, self_cons_share=1.0
+        assert pi.prod_adapters_self_cons_shares["pv"] == pytest.approx(
+            (1.0 * (2000 / 3500)) / 1.0
+        )
+        assert pi.prod_adapters_self_cons_shares["bat"] == pytest.approx(
+            (1.0 * (1000 / 3500)) / 1.0
+        )
+
+    def test_prod_adapters_self_cons_power(self, pi):
+        # production * self_cons_rate
+        assert pi.prod_adapters_self_cons_power["pv"] == pytest.approx(
+            2000 * 1.0
+        )
+        assert pi.prod_adapters_self_cons_power["bat"] == pytest.approx(
+            1000 * 1.0
+        )
+
+    def test_prod_adapters_self_cons_saving_rates(self, pi):
+        # self_cons_power_kW * grid_coe
+        assert pi.prod_adapters_self_cons_saving_rates["pv"] == pytest.approx(
+            (2000 / 1000) * GRID_PRICE_VALUE
+        )
+        assert pi.prod_adapters_self_cons_saving_rates["bat"] == pytest.approx(
+            (1000 / 1000) * GRID_PRICE_VALUE
+        )
+
+    def test_prod_adapters_coo_rates(self, pi):
+        # Both have consumption=0 → coo=0
+        assert pi.prod_adapters_coo_rates["pv"] == pytest.approx(0.0)
+        assert pi.prod_adapters_coo_rates["bat"] == pytest.approx(0.0)
+
+    def test_prod_adapters_saving_rates(self, pi):
+        # export_comp + self_cons_savings - coo - coe_rate
+        # PV: 0 + (2000/1000)*0.30 - 0 - 0 = 0.60
+        assert pi.prod_adapters_saving_rates["pv"] == pytest.approx(
+            0 + (2000 / 1000) * GRID_PRICE_VALUE - 0 - 0
+        )
+        # Battery: 0 + (1000/1000)*0.30 - 0 - 0 = 0.30
+        assert pi.prod_adapters_saving_rates["bat"] == pytest.approx(
+            0 + (1000 / 1000) * GRID_PRICE_VALUE - 0 - 0
+        )
+
+    def test_prod_adapters_levelized_saving_rates(self, pi):
+        # Same but subtracts lcoe_rate and lcoo_rate
+        # PV: 0 + (2000/1000)*0.30 - 0 - (2000/1000)*0.08
+        pv_self_cons_savings = (2000 / 1000) * GRID_PRICE_VALUE
+        pv_lcoe_rate = (2000 / 1000) * PV_LCOE
+        assert pi.prod_adapters_levelized_saving_rates["pv"] == pytest.approx(
+            0 + pv_self_cons_savings - 0 - pv_lcoe_rate
+        )
+        # Battery: 0 + (1000/1000)*0.30 - 0 - (1000/1000)*0.12
+        bat_self_cons_savings = (1000 / 1000) * GRID_PRICE_VALUE
+        bat_lcoe_rate = (1000 / 1000) * BAT_LCOS
+        assert pi.prod_adapters_levelized_saving_rates["bat"] == pytest.approx(
+            0 + bat_self_cons_savings - 0 - bat_lcoe_rate
+        )
+
+    # -- Totals --
+
+    def test_total_export_compensation_rate(self, pi):
+        assert pi.total_export_compensation_rate == pytest.approx(0.0)
+
+    def test_total_self_cons_saving_rate(self, pi):
+        assert pi.total_self_cons_saving_rate == pytest.approx(
+            (2000 / 1000) * GRID_PRICE_VALUE
+            + (1000 / 1000) * GRID_PRICE_VALUE
+        )
+
+    def test_total_coo_rate(self, pi):
+        assert pi.total_coo_rate == pytest.approx(0.0)
+
+    def test_total_lcoo_rate(self, pi):
+        assert pi.total_lcoo_rate == pytest.approx(0.0)
+
+    def test_total_saving_rate(self, pi):
+        pv_saving = 0 + (2000 / 1000) * GRID_PRICE_VALUE - 0 - 0
+        bat_saving = 0 + (1000 / 1000) * GRID_PRICE_VALUE - 0 - 0
+        assert pi.total_saving_rate == pytest.approx(pv_saving + bat_saving)
+
+    def test_total_levelized_saving_rate(self, pi):
+        pv_saving = (
+            0
+            + (2000 / 1000) * GRID_PRICE_VALUE
+            - 0
+            - (2000 / 1000) * PV_LCOE
+        )
+        bat_saving = (
+            0
+            + (1000 / 1000) * GRID_PRICE_VALUE
+            - 0
+            - (1000 / 1000) * BAT_LCOS
+        )
+        assert pi.total_levelized_saving_rate == pytest.approx(
+            pv_saving + bat_saving
+        )
+
+
+# ===================================================================
+# Scenario 3 — Grid + PV + Battery + Consumer
+# ===================================================================
+# Same power setup as scenario 2, plus a consumer at -800 W
+# Consumer power is negative (consuming).
+# ===================================================================
+
+class TestScenario3GridPvBatteryConsumer:
+    """Grid + PV + Battery + Consumer."""
+
+    @pytest.fixture()
+    def pi(self):
+        return _build_scenario([
+            _make_grid(500),
+            _make_pv(2000),
+            _make_battery(1000),
+            _make_consumer(-800),
+        ])
+
+    # -- Power flows are same as scenario 2 (consumer doesn't affect them) --
+
+    def test_total_power(self, pi):
+        # Consumer doesn't contribute to total_power (not a prod adapter)
+        assert pi.total_power == pytest.approx(500 + 2000 + 1000)
+
+    def test_self_consumption(self, pi):
+        assert pi.self_consumption == pytest.approx(3500.0)
+
+    # -- Consumer adapter properties --
+
+    def test_cons_adapter_total_power_shares(self, pi):
+        # consumer consumption / total_power
+        # ConsumerAdapter.consumption: power * -1 if power < 0 else 0
+        # power = -800 → consumption = 800
+        assert pi.cons_adapter_total_power_shares["cons"] == pytest.approx(
+            800 / 3500
+        )
+
+    def test_cons_adapters_self_cons_share(self, pi):
+        # power_share / self_cons_share
+        # = (800/3500) / (3500/3500) = 800/3500
+        assert pi.cons_adapters_self_cons_share["cons"] == pytest.approx(
+            (800 / 3500) / 1.0
+        )
+
+    def test_cons_adapters_source_shares(self, pi):
+        # Each power provider's self_cons_share is the same for all consumers
+        # Grid self_cons_share = (applicable_sc * grid_power_share) / sc_share
+        #   = (1.0 * 500/3500) / 1.0 = 500/3500
+        # PV self_cons_share = (1.0 * 2000/3500) / 1.0 = 2000/3500
+        # Bat self_cons_share = (1.0 * 1000/3500) / 1.0 = 1000/3500
+        shares = pi.cons_adapters_source_shares["cons"]
+        assert shares["grid"] == pytest.approx(
+            (1.0 * (500 / 3500)) / 1.0
+        )
+        assert shares["pv"] == pytest.approx(
+            (1.0 * (2000 / 3500)) / 1.0
+        )
+        assert shares["bat"] == pytest.approx(
+            (1.0 * (1000 / 3500)) / 1.0
+        )
+
+    def test_cons_adapters_coo_rates(self, pi):
+        # consumption_kW * coe (blended)
+        coe = ((500 / 1000) * GRID_PRICE_VALUE) / (3500 / 1000)
+        assert pi.cons_adapters_coo_rates["cons"] == pytest.approx(
+            (800 / 1000) * coe
+        )
+
+    def test_cons_adapters_lcoo_rates(self, pi):
+        # consumption_kW * lcoe (blended)
+        lcoe_rate = (
+            (500 / 1000) * GRID_PRICE_VALUE
+            + (2000 / 1000) * PV_LCOE
+            + (1000 / 1000) * BAT_LCOS
+        )
+        lcoe = lcoe_rate / (3500 / 1000)
+        assert pi.cons_adapters_lcoo_rates["cons"] == pytest.approx(
+            (800 / 1000) * lcoe
+        )
+
+    # -- Verify production adapters are unaffected by consumer --
+
+    def test_prod_adapters_saving_rates_unchanged(self, pi):
+        # Should be same as scenario 2
+        assert pi.prod_adapters_saving_rates["pv"] == pytest.approx(
+            0 + (2000 / 1000) * GRID_PRICE_VALUE - 0 - 0
+        )
+        assert pi.prod_adapters_saving_rates["bat"] == pytest.approx(
+            0 + (1000 / 1000) * GRID_PRICE_VALUE - 0 - 0
+        )


### PR DESCRIPTION
## Summary
This PR refactors the PowerInsight integration by extracting Home Assistant-specific code and adapter model logic into dedicated modules, improving separation of concerns and testability.

## Key Changes

- **New `event_handler.py` module**: Extracted `EventHandler` class from `power_insight.py` to isolate Home Assistant event bus integration logic
- **New `adapter_models.py` module**: Created dataclass-based adapter models (`GridAdapterModel`, `PvAdapterModel`, `BatteryAdapterModel`, `ConsumerAdapterModel`) with factory methods for creating adapter instances from config entries
- **Refactored `power_insight.py`**: 
  - Removed Home Assistant dependencies (imports from `homeassistant.const`, `homeassistant.core`, etc.)
  - Removed `EventHandler` class (moved to `event_handler.py`)
  - Removed `DEVICE_ADAPTERS` registry and `register_adapter()` function
  - Removed `from_entry()` class methods from adapter classes
  - Replaced exception handling with logging for data discrepancies
- **Updated `__init__.py`**: 
  - Import `EventHandler` from new `event_handler` module
  - Import adapter models from new `adapter_models` module
  - Updated adapter instantiation to use new model-based approach
- **Added comprehensive test suite** (`test_power_calculations.py`): 698 lines of tests covering three scenarios:
  - Grid + PV with excess production (exporting)
  - Grid + PV + Battery with all power consumed
  - Grid + PV + Battery + Consumer with cost allocation

## Notable Implementation Details

- The core `PowerInsight` calculation logic is now completely decoupled from Home Assistant, enabling unit testing without HA dependencies
- Adapter models use dataclasses with `from_subentry()` class methods and `create_adapter()` factory methods for clean separation between config data and adapter instantiation
- The `ADAPTER_MODELS` registry uses a decorator pattern for cleaner registration
- Tests import `power_insight.py` directly using `importlib.util` to bypass HA dependencies

https://claude.ai/code/session_01LRfcKkYYDxAuq7QhfLqSFo