### PR TITLE
Add grid adapter to charge sources and improve battery reconfiguration

### DIFF
--- a/custom_components/power_insight/__init__.py
+++ b/custom_components/power_insight/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.exceptions import ConfigEntryNotReady
 
 
-from .const import DOMAIN, PLATFORMS
+from .const import CONF_CHARGE_FROM_ADAPTERS, DOMAIN, PLATFORMS
 from .utils import state_to_value
 from .power_insight import PowerInsight
 from .event_handler import EventHandler
@@ -50,18 +50,40 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
     
     if power_insight.grid_adapter is None:
         ir.async_create_issue(
-        hass,
-        DOMAIN,
-        "no_grid_configured",
-        is_fixable=False,
-        severity=ir.IssueSeverity.ERROR,
-        translation_key="no_grid_configured",
-        translation_placeholders={"entry_title": entry.title},
+            hass,
+            DOMAIN,
+            "no_grid_configured",
+            is_fixable=False,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="no_grid_configured",
+            translation_placeholders={"entry_title": entry.title},
         )
         raise ConfigEntryNotReady("grid_not_configured")
-    
-    # Grid is present — dismiss any previously raised issue
+
+    # Grid is present — dismiss any previously raised issue.
     ir.async_delete_issue(hass, DOMAIN, "no_grid_configured")
+
+    # Raise a repair issue for each battery adapter whose charge_from_adapters
+    # contains stale references (i.e. adapters that have since been removed).
+    valid_source_ids = {
+        sub.subentry_id
+        for sub in entry.subentries.values()
+        if sub.data.get("adapter", {}).get("adapter_type") in ("grid", "pv_system")
+    }
+    for subentry in entry.subentries.values():
+        if subentry.data.get("adapter", {}).get("adapter_type") != "battery":
+            continue
+        charge_from = subentry.data["adapter"]["config"].get(CONF_CHARGE_FROM_ADAPTERS, [])
+        if any(source_id not in valid_source_ids for source_id in charge_from):
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                f"reconfigure_battery_{subentry.subentry_id}",
+                is_fixable=False,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key="reconfigure_battery_adapters",
+                translation_placeholders={"battery_name": subentry.title},
+            )
 
     source_entities = power_insight.source_entities
 

--- a/custom_components/power_insight/__init__.py
+++ b/custom_components/power_insight/__init__.py
@@ -3,7 +3,7 @@
 import logging
 from dataclasses import dataclass
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigSubentry
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.const import STATE_UNAVAILABLE
@@ -142,6 +142,33 @@ async def async_unload_entry(
     event_handler.untrack_entities()
 
     return unload
+
+
+async def async_remove_subentry(
+    hass: HomeAssistant,
+    entry: MyConfigEntry,
+    subentry: ConfigSubentry,
+) -> None:
+    """Raise repair issues for batteries that referenced the removed adapter."""
+    removed_type = subentry.data.get("adapter", {}).get("adapter_type")
+    if removed_type not in ("grid", "pv_system"):
+        return
+
+    removed_id = subentry.subentry_id
+    for remaining in entry.subentries.values():
+        if remaining.data.get("adapter", {}).get("adapter_type") != "battery":
+            continue
+        charge_from = remaining.data["adapter"]["config"].get(CONF_CHARGE_FROM_ADAPTERS, [])
+        if removed_id in charge_from:
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                f"reconfigure_battery_{remaining.subentry_id}",
+                is_fixable=False,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key="reconfigure_battery_adapters",
+                translation_placeholders={"battery_name": remaining.title},
+            )
 
 
 async def async_migrate_entry(

--- a/custom_components/power_insight/config_flow.py
+++ b/custom_components/power_insight/config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.config_entries import (
 )
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers import selector
+from homeassistant.helpers import issue_registry as ir, selector
 from homeassistant.const import CONF_NAME
 from homeassistant.util import slugify
 
@@ -149,12 +149,32 @@ def _build_charge_from_selector(
     """Build the dynamic multi-select selector for charge_from_adapters.
 
     Called by ``build_schema`` when resolving ``AdapterField.selector_fn``
-    for ``CONF_CHARGE_FROM_ADAPTERS``.
+    for ``CONF_CHARGE_FROM_ADAPTERS``.  Includes the grid adapter (if
+    configured) followed by all PV-system adapters.
     """
-    pv_options = _get_pv_adapter_options(entry, exclude_subentry_id=exclude_subentry_id)
+    options: list[selector.SelectOptionDict] = []
+
+    # Include the grid adapter as a selectable charge source.
+    for subentry in entry.subentries.values():
+        if exclude_subentry_id and subentry.subentry_id == exclude_subentry_id:
+            continue
+        adapter = subentry.data.get("adapter", {})
+        if adapter.get("adapter_type") == "grid":
+            options.append(
+                selector.SelectOptionDict(
+                    value=subentry.subentry_id,
+                    label="Grid",
+                )
+            )
+
+    # Include PV-system adapters.
+    options.extend(
+        _get_pv_adapter_options(entry, exclude_subentry_id=exclude_subentry_id)
+    )
+
     return selector.SelectSelector(
         selector.SelectSelectorConfig(
-            options=pv_options,
+            options=options,
             multiple=True,
             mode=selector.SelectSelectorMode.LIST,
         )
@@ -655,14 +675,6 @@ BATTERY_FIELDS: dict[str, AdapterField | CalculatedAdapterField] = {
         default=0.0,
         in_config_flow=True,
         in_reconfigure_flow=False,
-        store_in_adapter_config=True,
-    ),
-    CONF_CHARGE_FROM_GRID: AdapterField(
-        selector=BOOLEAN_SELECTOR,
-        required=True,
-        default=True,
-        in_config_flow=True,
-        in_reconfigure_flow=True,
         store_in_adapter_config=True,
     ),
     CONF_CHARGE_FROM_ADAPTERS: AdapterField(
@@ -1224,10 +1236,21 @@ class AdapterSubentryFlow(ConfigSubentryFlow):
 
                 result = self.async_create_entry(title=title, data=entry_data)
 
-                # Reload the parent entry so the repair-issue check in
-                # async_setup_entry fires immediately for grid and pv_system
-                # additions (batteries don't affect other batteries).
+                # When a charge source (grid or pv_system) is added, prompt
+                # every existing battery adapter to be reconfigured so the user
+                # can update their charge_from_adapters settings.
                 if self._adapter_type in ("grid", "pv_system"):
+                    for sub in parent_entry.subentries.values():
+                        if sub.data.get("adapter", {}).get("adapter_type") == "battery":
+                            ir.async_create_issue(
+                                self.hass,
+                                DOMAIN,
+                                f"reconfigure_battery_{sub.subentry_id}",
+                                is_fixable=False,
+                                severity=ir.IssueSeverity.WARNING,
+                                translation_key="reconfigure_battery_adapters",
+                                translation_placeholders={"battery_name": sub.title},
+                            )
                     self.hass.async_create_task(
                         self.hass.config_entries.async_reload(parent_entry.entry_id)
                     )
@@ -1288,8 +1311,12 @@ class AdapterSubentryFlow(ConfigSubentryFlow):
                     "key": adapter.get("key"),
                     "config": adapter_config,
                 }
-                # async_update_reload_and_abort triggers a reload so
-                # async_setup_entry will clear the repair issue automatically.
+                # Dismiss the per-battery reconfigure issue (raised when a
+                # charge-source adapter was added or removed) now that the
+                # user has reconfigured this battery.
+                ir.async_delete_issue(
+                    self.hass, DOMAIN, f"reconfigure_battery_{subentry.subentry_id}"
+                )
                 return self.async_update_reload_and_abort(
                     self._get_entry(), subentry, data=updated
                 )
@@ -1303,14 +1330,15 @@ class AdapterSubentryFlow(ConfigSubentryFlow):
 
         # For charge_from_adapters, strip stale subentry IDs before seeding so
         # the selector is pre-populated with only currently valid selections.
+        # Valid sources are grid and pv_system adapters.
         if CONF_CHARGE_FROM_ADAPTERS in seed:
-            valid_pv_ids = {
+            valid_source_ids = {
                 sub.subentry_id
                 for sub in parent_entry.subentries.values()
-                if sub.data.get("adapter", {}).get("adapter_type") == "pv_system"
+                if sub.data.get("adapter", {}).get("adapter_type") in ("grid", "pv_system")
             }
             seed[CONF_CHARGE_FROM_ADAPTERS] = [
-                i for i in seed[CONF_CHARGE_FROM_ADAPTERS] if i in valid_pv_ids
+                i for i in seed[CONF_CHARGE_FROM_ADAPTERS] if i in valid_source_ids
             ]
 
         schema = build_schema(

--- a/custom_components/power_insight/translations/en.json
+++ b/custom_components/power_insight/translations/en.json
@@ -80,6 +80,7 @@
             "exports_power": "Exports Power to Grid",
             "export_compensation": "Export Compensation Rate",
             "battery_efficiency": "Round-Trip Efficiency",
+            "charge_from_adapters": "Charge From",
             "lifetime_production": "Lifetime Production",
             "lifetime_cost": "Total Lifetime Cost",
             "co2_footprint": "CO\u2082 Footprint"
@@ -93,6 +94,7 @@
             "exports_power": "Enable if this device can export excess power to the grid.",
             "export_compensation": "Rate received per kWh exported to the grid (\u20ac/kWh). Required when cost savings calculation is enabled.",
             "battery_efficiency": "The round-trip efficiency of the battery in percent.",
+            "charge_from_adapters": "Select which adapters (grid and/or PV systems) this battery is allowed to charge from.",
             "lifetime_production": "Total expected energy production over the device lifetime (kWh). Required when levelized calculation is enabled.",
             "lifetime_cost": "Total investment and installation cost over the device lifetime (\u20ac). Required when levelized cost calculation is enabled.",
             "co2_footprint": "Total CO\u2082 emissions from manufacturing and installation (kg). Required when levelized CO\u2082 calculation is enabled."
@@ -105,13 +107,15 @@
             "power_entity": "Power Entity",
             "power_entity_inverted": "Invert Power Direction",
             "grid_electricity_price_entity": "Electricity Price Entity",
-            "co2_intensity_entity": "CO\u2082 Intensity Entity"
+            "co2_intensity_entity": "CO\u2082 Intensity Entity",
+            "charge_from_adapters": "Charge From"
           },
           "data_description": {
             "power_entity": "Sensor reporting power in W, kW, or MW.",
             "power_entity_inverted": "Enable if your sensor reports the power direction inverted.",
             "grid_electricity_price_entity": "Sensor or input number providing the current electricity price in \u20ac/kWh. Required when cost calculations are enabled.",
-            "co2_intensity_entity": "Sensor providing the current grid CO\u2082 intensity in g/kWh. Required when CO\u2082 calculations are enabled."
+            "co2_intensity_entity": "Sensor providing the current grid CO\u2082 intensity in g/kWh. Required when CO\u2082 calculations are enabled.",
+            "charge_from_adapters": "Select which adapters (grid and/or PV systems) this battery is allowed to charge from."
           }
         }
       },
@@ -134,6 +138,10 @@
     "no_grid_configured": {
       "title": "No grid configured for {entry_title}",
       "description": "The Power Insight integration **{entry_title}** could not load because no grid adapter has been configured. Open the integration and use the **Add device** button to add a Grid adapter."
+    },
+    "reconfigure_battery_adapters": {
+      "title": "Battery '{battery_name}' needs reconfiguration",
+      "description": "An adapter was added or removed. Please reconfigure **{battery_name}** to ensure the correct charge sources are applied. Open the integration, find the device, and use the **Reconfigure** option."
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR enhances the Power Insight integration's battery charging configuration by allowing batteries to charge from both grid and PV-system adapters (previously only PV systems), and adds automatic repair issues to prompt battery reconfiguration when charge sources are added or removed.

## Key Changes

- **Expanded charge sources**: Batteries can now charge from grid adapters in addition to PV-system adapters
  - Updated `_build_charge_from_selector()` to include grid adapter as a selectable charge source
  - Removed the separate `CONF_CHARGE_FROM_GRID` boolean field in favor of the unified `CONF_CHARGE_FROM_ADAPTERS` multi-select

- **Automatic repair issue management**:
  - Added validation in `async_setup_entry()` to detect stale adapter references in battery configurations and raise repair issues
  - Implemented new `async_remove_subentry()` handler to raise repair issues when grid or PV-system adapters are removed
  - Repair issues are automatically dismissed when users reconfigure affected batteries

- **Improved user experience**:
  - When a charge source (grid or PV system) is added, all existing batteries are prompted to reconfigure via repair issues
  - Stale adapter references are automatically filtered out when seeding the reconfigure flow
  - Added translations for the new "Charge From" field and battery reconfiguration repair issue

- **Code quality improvements**:
  - Fixed indentation in `async_setup_entry()` for the grid configuration issue
  - Updated comments to clarify the repair issue workflow
  - Imported `ConfigSubentry` and `issue_registry` where needed

## Implementation Details

The solution uses Home Assistant's repair issue system to guide users through necessary reconfigurations. When a charge source adapter is added or removed, affected batteries are flagged with a repair issue that can be resolved by reconfiguring the battery's charge sources. This ensures data consistency and prevents silent failures from stale adapter references.

https://claude.ai/code/session_01M26a9tKwwuzt8ggUx1Wwzq