### PR TITLE
Refactor sensor definitions and PowerInsight API alignment

### DIFF
--- a/custom_components/power_insight/power_insight.py
+++ b/custom_components/power_insight/power_insight.py
@@ -252,15 +252,6 @@ class PowerInsight:
         return power
 
     @property
-    def combined_utilization(self) -> float | None:
-        """Sum of power used for battery charging and production adapter standby (W)."""
-        if (charging := self.combined_charging_power) is None:
-            return None
-        if (standby := self.combined_standby_power) is None:
-            return None
-        return charging + standby
-
-    @property
     def combined_consumption(self) -> float | None:
         """Sum of power consumed by electrical loads (W).
 
@@ -382,15 +373,6 @@ class PowerInsight:
             _LOGGER.warning("Data discrepancy: utilization without total power.")
 
         return self._divide(charging_power, gross_power)
-
-    @property
-    def gross_power_utilization_ratio(self) -> float | None:
-        """Fraction of gross power used for charging and standby."""
-        if (charging_ratio := self.gross_power_charging_ratio) is None:
-            return None
-        if (standby_ratio := self.gross_power_standby_ratio) is None:
-            return None
-        return charging_ratio + standby_ratio
 
     # --------------------------------->
     # APPLICABLE GROSS POWER RATIOS --->
@@ -696,11 +678,6 @@ class PowerInsight:
     def grid_adapters_export_power(self) -> dict[str, float | None]:
         """Return the grid adapter's export power keyed by uid."""
         return {self.grid_adapter.uid: self.combined_grid_export}
-
-    @property
-    def grid_adapters_export_ratio(self) -> dict[str, float | None]:
-        """Return the gross power export ratio keyed by grid adapter uid."""
-        return {self.grid_adapter.uid: self.gross_power_export_ratio}
 
     @property
     def grid_adapters_coe_rate(self) -> dict[str, float | None]:

--- a/custom_components/power_insight/power_insight.py
+++ b/custom_components/power_insight/power_insight.py
@@ -252,6 +252,15 @@ class PowerInsight:
         return power
 
     @property
+    def combined_utilization(self) -> float | None:
+        """Sum of power used for battery charging and production adapter standby (W)."""
+        if (charging := self.combined_charging_power) is None:
+            return None
+        if (standby := self.combined_standby_power) is None:
+            return None
+        return charging + standby
+
+    @property
     def combined_consumption(self) -> float | None:
         """Sum of power consumed by electrical loads (W).
 
@@ -373,6 +382,15 @@ class PowerInsight:
             _LOGGER.warning("Data discrepancy: utilization without total power.")
 
         return self._divide(charging_power, gross_power)
+
+    @property
+    def gross_power_utilization_ratio(self) -> float | None:
+        """Fraction of gross power used for charging and standby."""
+        if (charging_ratio := self.gross_power_charging_ratio) is None:
+            return None
+        if (standby_ratio := self.gross_power_standby_ratio) is None:
+            return None
+        return charging_ratio + standby_ratio
 
     # --------------------------------->
     # APPLICABLE GROSS POWER RATIOS --->
@@ -668,6 +686,30 @@ class PowerInsight:
     #         )
 
     #     return shares
+
+    @property
+    def grid_adapters_import_power(self) -> dict[str, float | None]:
+        """Return the grid adapter's import power keyed by uid."""
+        return {self.grid_adapter.uid: self.combined_grid_import}
+
+    @property
+    def grid_adapters_export_power(self) -> dict[str, float | None]:
+        """Return the grid adapter's export power keyed by uid."""
+        return {self.grid_adapter.uid: self.combined_grid_export}
+
+    @property
+    def grid_adapters_export_ratio(self) -> dict[str, float | None]:
+        """Return the gross power export ratio keyed by grid adapter uid."""
+        return {self.grid_adapter.uid: self.gross_power_export_ratio}
+
+    @property
+    def grid_adapters_coe_rate(self) -> dict[str, float | None]:
+        """Return the grid import cost rate (EUR/h) keyed by uid."""
+        if (import_power := self.combined_grid_import) is None:
+            return {self.grid_adapter.uid: None}
+        if (coe := self.grid_adapter.coe) is None:
+            return {self.grid_adapter.uid: None}
+        return {self.grid_adapter.uid: (import_power / 1000) * coe}
 
     @property
     def grid_adapters_charging_shares(self) -> dict[str, float]:
@@ -1409,9 +1451,9 @@ class PowerInsight:
                 total_share += share
                 charging_shares[adapter_uid][battery.uid] = share
 
-            for adapter_uid in charge_from.items():
+            for adapter_uid in charge_from:
                 share = charging_shares[adapter_uid][battery.uid]
-                share = self._divide(share, total_share)
+                charging_shares[adapter_uid][battery.uid] = self._divide(share, total_share)
 
         return charging_shares
 

--- a/custom_components/power_insight/sensor.py
+++ b/custom_components/power_insight/sensor.py
@@ -135,24 +135,45 @@ POWER_INSIGHT_SENSORS = (
         value_fn=lambda obj: obj.combined_avoided_cost_rate,
     ),
     PowerInsightSensorDescription(
-        key="combined_utilization_power",
-        name="Combined utilization power",
+        key="combined_charging_power",
+        name="Combined charging power",
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.POWER,
         suggested_display_precision=0,
         entities_fn=lambda obj: obj.source_entities_power,
-        value_fn=lambda obj: obj.combined_utilization,
+        value_fn=lambda obj: obj.combined_charging_power,
     ),
     PowerInsightSensorDescription(
-        key="combined_utilization_ratio",
-        name="Combined utilization ratio",
+        key="combined_standby_power",
+        name="Combined standby power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        suggested_display_precision=0,
+        entities_fn=lambda obj: obj.source_entities_power,
+        value_fn=lambda obj: obj.combined_standby_power,
+    ),
+    PowerInsightSensorDescription(
+        key="combined_charging_ratio",
+        name="Combined charging ratio",
         icon="mdi:percent",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
         entities_fn=lambda obj: obj.source_entities_power,
-        value_fn=lambda obj: obj.gross_power_utilization_ratio,
+        value_fn=lambda obj: obj.gross_power_charging_ratio,
+        transform_fn=lambda val: val * 100,
+    ),
+    PowerInsightSensorDescription(
+        key="combined_standby_ratio",
+        name="Combined standby ratio",
+        icon="mdi:percent",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        entities_fn=lambda obj: obj.source_entities_power,
+        value_fn=lambda obj: obj.gross_power_standby_ratio,
         transform_fn=lambda val: val * 100,
     ),
     PowerInsightSensorDescription(
@@ -343,37 +364,6 @@ POWER_INSIGHT_INTEGRATION_SENSORS = (
 
 POWER_INSIGHT_GRID_ADAPTER_SENSORS = (
     PowerInsightSensorDescription(
-        key="import_power",
-        name="Import power",
-        native_unit_of_measurement=UnitOfPower.WATT,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.POWER,
-        suggested_display_precision=0,
-        entities_fn=lambda obj: obj.source_entities_power,
-        value_fn=lambda obj: obj.grid_adapters_import_power,
-    ),
-    PowerInsightSensorDescription(
-        key="export_power",
-        name="Export power",
-        native_unit_of_measurement=UnitOfPower.WATT,
-        state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.POWER,
-        suggested_display_precision=0,
-        entities_fn=lambda obj: obj.source_entities_power,
-        value_fn=lambda obj: obj.grid_adapters_export_power,
-    ),
-    PowerInsightSensorDescription(
-        key="export_ratio",
-        name="Export ratio",
-        icon="mdi:percent",
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=0,
-        entities_fn=lambda obj: obj.source_entities_power,
-        value_fn=lambda obj: obj.grid_adapters_export_ratio,
-        transform_fn=lambda val: val * 100,
-    ),
-    PowerInsightSensorDescription(
         key="cost_rate",
         name="Cost rate",
         icon="mdi:currency-eur",
@@ -384,6 +374,73 @@ POWER_INSIGHT_GRID_ADAPTER_SENSORS = (
         exists_fn=lambda options: options.check(CONF_CALCULATE_COST_RATES),
         value_fn=lambda obj: obj.grid_adapters_coe_rate,
     ),
+    PowerInsightSensorDescription(
+        key="consumption_ratio",
+        name="Consumption ratio",
+        icon="mdi:percent",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        entities_fn=lambda obj: obj.source_entities_power,
+        value_fn=lambda obj: obj.grid_adapters_consumption_ratios,
+        transform_fn=lambda val: val * 100,
+    ),
+    PowerInsightSensorDescription(
+        key="consumption_share",
+        name="Consumption share",
+        icon="mdi:percent",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        entities_fn=lambda obj: obj.source_entities_power,
+        value_fn=lambda obj: obj.grid_adapters_consumption_shares,
+        transform_fn=lambda val: val * 100,
+    ),
+    # --- Requires new power_insight.py dict-properties; uncomment when ready ---
+    # PowerInsightSensorDescription(
+    #     key="charging_ratio",
+    #     name="Charging ratio",
+    #     icon="mdi:percent",
+    #     native_unit_of_measurement=PERCENTAGE,
+    #     state_class=SensorStateClass.MEASUREMENT,
+    #     suggested_display_precision=0,
+    #     entities_fn=lambda obj: obj.source_entities_power,
+    #     value_fn=lambda obj: obj.grid_adapters_charging_ratio,
+    #     transform_fn=lambda val: val * 100,
+    # ),
+    # PowerInsightSensorDescription(
+    #     key="charging_share",
+    #     name="Charging share",
+    #     icon="mdi:percent",
+    #     native_unit_of_measurement=PERCENTAGE,
+    #     state_class=SensorStateClass.MEASUREMENT,
+    #     suggested_display_precision=0,
+    #     entities_fn=lambda obj: obj.source_entities_power,
+    #     value_fn=lambda obj: obj.grid_adapters_combined_charging_share,
+    #     transform_fn=lambda val: val * 100,
+    # ),
+    # PowerInsightSensorDescription(
+    #     key="standby_ratio",
+    #     name="Standby ratio",
+    #     icon="mdi:percent",
+    #     native_unit_of_measurement=PERCENTAGE,
+    #     state_class=SensorStateClass.MEASUREMENT,
+    #     suggested_display_precision=0,
+    #     entities_fn=lambda obj: obj.source_entities_power,
+    #     value_fn=lambda obj: obj.grid_adapters_standby_ratio,
+    #     transform_fn=lambda val: val * 100,
+    # ),
+    # PowerInsightSensorDescription(
+    #     key="standby_share",
+    #     name="Standby share",
+    #     icon="mdi:percent",
+    #     native_unit_of_measurement=PERCENTAGE,
+    #     state_class=SensorStateClass.MEASUREMENT,
+    #     suggested_display_precision=0,
+    #     entities_fn=lambda obj: obj.source_entities_power,
+    #     value_fn=lambda obj: obj.grid_adapters_standby_share,
+    #     transform_fn=lambda val: val * 100,
+    # ),
 )
 
 POWER_INSIGHT_GRID_ADAPTER_INTEGRATION_SENSORS = (
@@ -402,10 +459,10 @@ POWER_INSIGHT_GRID_ADAPTER_INTEGRATION_SENSORS = (
 
 
 # ---------------------------------------------------------------------------
-# Production adapter sensors (PV + Battery — shared)
+# PV adapter sensors
 # ---------------------------------------------------------------------------
 
-POWER_INSIGHT_PROD_ADAPTER_SENSORS = (
+POWER_INSIGHT_PV_ADAPTER_SENSORS = (
     PowerInsightSensorDescription(
         key="export_power",
         name="Export power",
@@ -548,7 +605,7 @@ POWER_INSIGHT_PROD_ADAPTER_SENSORS = (
     ),
 )
 
-POWER_INSIGHT_PROD_ADAPTER_INTEGRATION_SENSORS = (
+POWER_INSIGHT_PV_ADAPTER_INTEGRATION_SENSORS = (
     PowerInsightIntegrationSensorDescription(
         key="total_export_compensation",
         name="Total export compensation",
@@ -626,16 +683,230 @@ POWER_INSIGHT_PROD_ADAPTER_INTEGRATION_SENSORS = (
 
 
 # ---------------------------------------------------------------------------
-# Battery-specific sensors (in addition to POWER_INSIGHT_PROD_ADAPTER_SENSORS)
+# Storage (battery) adapter sensors
 # ---------------------------------------------------------------------------
+# Identical structure to POWER_INSIGHT_PV_ADAPTER_SENSORS but pointing to
+# storage_adapters_* properties.  Charging-source-share sensors are added
+# dynamically in async_setup_entry.
 
-# Charging source share sensors are created dynamically per battery in
-# async_setup_entry, one per power-providing adapter, using
-# storage_adapters_charging_source_shares.
-POWER_INSIGHT_BATTERY_ADAPTER_SENSORS: tuple[PowerInsightSensorDescription, ...] = ()
-POWER_INSIGHT_BATTERY_ADAPTER_INTEGRATION_SENSORS: tuple[
-    PowerInsightIntegrationSensorDescription, ...
-] = ()
+POWER_INSIGHT_STORAGE_ADAPTER_SENSORS = (
+    PowerInsightSensorDescription(
+        key="export_power",
+        name="Export power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        suggested_display_precision=0,
+        entities_fn=lambda obj: obj.source_entities_power,
+        exists_fn=lambda adapter: adapter.exports_power,
+        value_fn=lambda obj: obj.storage_adapters_export_power,
+    ),
+    PowerInsightSensorDescription(
+        key="export_ratio",
+        name="Export ratio",
+        icon="mdi:percent",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        entities_fn=lambda obj: obj.source_entities_power,
+        exists_fn=lambda adapter: adapter.exports_power,
+        value_fn=lambda obj: obj.storage_adapters_export_ratios,
+        transform_fn=lambda val: val * 100,
+    ),
+    PowerInsightSensorDescription(
+        key="export_share",
+        name="Export share",
+        icon="mdi:percent",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        entities_fn=lambda obj: obj.source_entities_power,
+        exists_fn=lambda adapter: adapter.exports_power,
+        value_fn=lambda obj: obj.storage_adapters_export_shares,
+        transform_fn=lambda val: val * 100,
+    ),
+    PowerInsightSensorDescription(
+        key="export_compensation_rate",
+        name="Export compensation rate",
+        icon="mdi:currency-eur",
+        native_unit_of_measurement="EUR/h",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: (
+            obj.source_entities_price + obj.source_entities_power
+        ),
+        exists_fn=lambda adapter: adapter.exports_power,
+        value_fn=lambda obj: obj.storage_adapters_export_compensation_rates,
+    ),
+    PowerInsightSensorDescription(
+        key="self_consumption_power",
+        name="Self-consumption power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        suggested_display_precision=0,
+        entities_fn=lambda obj: obj.source_entities_power,
+        value_fn=lambda obj: obj.storage_adapters_consumption_power,
+    ),
+    PowerInsightSensorDescription(
+        key="self_consumption_ratio",
+        name="Self-consumption ratio",
+        icon="mdi:percent",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        entities_fn=lambda obj: obj.source_entities_power,
+        value_fn=lambda obj: obj.storage_adapters_consumption_ratios,
+        transform_fn=lambda val: val * 100,
+    ),
+    PowerInsightSensorDescription(
+        key="self_consumption_share",
+        name="Self-consumption share",
+        icon="mdi:percent",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        entities_fn=lambda obj: obj.source_entities_power,
+        value_fn=lambda obj: obj.storage_adapters_consumption_shares,
+        transform_fn=lambda val: val * 100,
+    ),
+    PowerInsightSensorDescription(
+        key="self_consumption_cost_savings_rate",
+        name="Self-consumption cost savings rate",
+        icon="mdi:currency-eur",
+        native_unit_of_measurement="EUR/h",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: (
+            obj.source_entities_price + obj.source_entities_power
+        ),
+        value_fn=lambda obj: obj.storage_adapters_avoided_cost_rates,
+    ),
+    PowerInsightSensorDescription(
+        key="operating_cost_rate",
+        name="Operating cost rate",
+        icon="mdi:currency-eur",
+        native_unit_of_measurement="EUR/h",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: (
+            obj.source_entities_price + obj.source_entities_power
+        ),
+        value_fn=lambda obj: obj.storage_adapters_coo_rates,
+    ),
+    PowerInsightSensorDescription(
+        key="levelized_operating_cost_rate",
+        name="Levelized operating cost rate",
+        icon="mdi:currency-eur",
+        native_unit_of_measurement="EUR/h",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: (
+            obj.source_entities_price + obj.source_entities_power
+        ),
+        value_fn=lambda obj: obj.storage_adapters_lcoo_rates,
+    ),
+    PowerInsightSensorDescription(
+        key="cost_savings_rate",
+        name="Cost savings rate",
+        icon="mdi:currency-eur",
+        native_unit_of_measurement="EUR/h",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: (
+            obj.source_entities_price + obj.source_entities_power
+        ),
+        value_fn=lambda obj: obj.storage_adapters_cost_saving_rates,
+    ),
+    PowerInsightSensorDescription(
+        key="levelized_cost_savings_rate",
+        name="Levelized cost savings rate",
+        icon="mdi:currency-eur",
+        native_unit_of_measurement="EUR/h",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: (
+            obj.source_entities_price + obj.source_entities_power
+        ),
+        value_fn=lambda obj: obj.storage_adapters_levelized_cost_saving_rates,
+    ),
+)
+
+POWER_INSIGHT_STORAGE_ADAPTER_INTEGRATION_SENSORS = (
+    PowerInsightIntegrationSensorDescription(
+        key="total_export_compensation",
+        name="Total export compensation",
+        native_unit_of_measurement="EUR",
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: (
+            obj.source_entities_price + obj.source_entities_power
+        ),
+        exists_fn=lambda adapter: adapter.exports_power,
+        integration_value_fn=lambda obj: obj.storage_adapters_export_compensation_rates,
+    ),
+    PowerInsightIntegrationSensorDescription(
+        key="total_operating_costs",
+        name="Total operating costs",
+        native_unit_of_measurement="EUR",
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: (
+            obj.source_entities_price + obj.source_entities_power
+        ),
+        integration_value_fn=lambda obj: obj.storage_adapters_coo_rates,
+    ),
+    PowerInsightIntegrationSensorDescription(
+        key="total_levelized_operating_costs",
+        name="Total levelized operating costs",
+        native_unit_of_measurement="EUR",
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: (
+            obj.source_entities_price + obj.source_entities_power
+        ),
+        integration_value_fn=lambda obj: obj.storage_adapters_lcoo_rates,
+    ),
+    PowerInsightIntegrationSensorDescription(
+        key="total_self_consumption_cost_savings",
+        name="Total self-consumption cost savings",
+        native_unit_of_measurement="EUR",
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: (
+            obj.source_entities_price + obj.source_entities_power
+        ),
+        integration_value_fn=lambda obj: obj.storage_adapters_avoided_cost_rates,
+    ),
+    PowerInsightIntegrationSensorDescription(
+        key="total_cost_savings",
+        name="Total cost savings",
+        native_unit_of_measurement="EUR",
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: (
+            obj.source_entities_price + obj.source_entities_power
+        ),
+        integration_value_fn=lambda obj: obj.storage_adapters_cost_saving_rates,
+    ),
+    PowerInsightIntegrationSensorDescription(
+        key="total_levelized_cost_savings",
+        name="Total levelized cost savings",
+        native_unit_of_measurement="EUR",
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: (
+            obj.source_entities_price + obj.source_entities_power
+        ),
+        integration_value_fn=lambda obj: obj.storage_adapters_levelized_cost_saving_rates,
+    ),
+)
 
 
 # ---------------------------------------------------------------------------
@@ -765,7 +1036,7 @@ async def async_setup_entry(
     # --- PV adapter sensors ---
     for adapter in power_insight.pv_system_adapters:
         entities = []
-        for description in POWER_INSIGHT_PROD_ADAPTER_SENSORS:
+        for description in POWER_INSIGHT_PV_ADAPTER_SENSORS:
             if not description.exists_fn(adapter):
                 continue
             entities.append(PowerInsightAdapterSensor(
@@ -776,7 +1047,7 @@ async def async_setup_entry(
                 device_adapter=adapter,
             ))
 
-        for description in POWER_INSIGHT_PROD_ADAPTER_INTEGRATION_SENSORS:
+        for description in POWER_INSIGHT_PV_ADAPTER_INTEGRATION_SENSORS:
             if not description.exists_fn(adapter):
                 continue
             entities.append(PowerInsightAdapterIntegrationSensor(
@@ -793,8 +1064,7 @@ async def async_setup_entry(
     for adapter in power_insight.storage_adapters:
         entities = []
 
-        # Shared production adapter sensors
-        for description in POWER_INSIGHT_PROD_ADAPTER_SENSORS:
+        for description in POWER_INSIGHT_STORAGE_ADAPTER_SENSORS:
             if not description.exists_fn(adapter):
                 continue
             entities.append(PowerInsightAdapterSensor(
@@ -805,30 +1075,7 @@ async def async_setup_entry(
                 device_adapter=adapter,
             ))
 
-        for description in POWER_INSIGHT_PROD_ADAPTER_INTEGRATION_SENSORS:
-            if not description.exists_fn(adapter):
-                continue
-            entities.append(PowerInsightAdapterIntegrationSensor(
-                description=description,
-                config_entry=entry,
-                source_entities=description.entities_fn(power_insight),
-                power_insight=power_insight,
-                device_adapter=adapter,
-            ))
-
-        # Battery-specific static sensors
-        for description in POWER_INSIGHT_BATTERY_ADAPTER_SENSORS:
-            if not description.exists_fn(adapter):
-                continue
-            entities.append(PowerInsightAdapterSensor(
-                description=description,
-                config_entry=entry,
-                source_entities=description.entities_fn(power_insight),
-                power_insight=power_insight,
-                device_adapter=adapter,
-            ))
-
-        for description in POWER_INSIGHT_BATTERY_ADAPTER_INTEGRATION_SENSORS:
+        for description in POWER_INSIGHT_STORAGE_ADAPTER_INTEGRATION_SENSORS:
             if not description.exists_fn(adapter):
                 continue
             entities.append(PowerInsightAdapterIntegrationSensor(

--- a/custom_components/power_insight/sensor.py
+++ b/custom_components/power_insight/sensor.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-# from operator import attrgetter
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -13,17 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.const import (
     PERCENTAGE,
-    CURRENCY_EURO,
-    UnitOfEnergy,
     UnitOfPower,
-    UnitOfTime,
-)
-from homeassistant.components.integration.const import (
-    METHOD_LEFT,
-)
-from homeassistant.helpers.device import async_device_info_to_link_from_entity
-from homeassistant.components.integration.sensor import (
-    IntegrationSensor,
 )
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -33,7 +22,7 @@ from homeassistant.components.sensor import (
 
 from .entity import BaseEventSensorEntity, BaseEventIntegrationSensorEntity
 from .utils import get_value
-from .power_insight import PowerInsight
+from .power_insight import PowerInsight, AbstractBaseAdapter
 from . import MyConfigEntry
 from .const import (
     DOMAIN,
@@ -42,7 +31,6 @@ from .const import (
     CONF_CALCULATE_LEVELIZED_COST_RATES,
     CONF_CALCULATE_COST_SAVING_RATES,
     CONF_CALCULATE_LEVELIZED_COST_SAVING_RATES,
-
     CONF_ACCUMULATE_COST_RATES,
     CONF_ACCUMULATE_LEVELIZED_COST_RATES,
     CONF_ACCUMULATE_COST_SAVING_RATES,
@@ -54,27 +42,27 @@ _LOGGER = logging.getLogger(__name__)
 
 @dataclass(frozen=True, kw_only=True)
 class PowerInsightSensorDescription(SensorEntityDescription):
-    """Provide the description of a Power insight sensor."""
+    """Provide the description of a PowerInsight sensor."""
 
-    entities_fn: Callable[[dict], float | None]
-    exists_fn: Callable[[dict], bool] = lambda value: True
-    value_fn: Callable[[dict], float | None]
-    transform_fn: Callable = lambda value: value
+    entities_fn: Callable[[PowerInsight], list[str]]
+    exists_fn: Callable[..., bool] = lambda _: True
+    value_fn: Callable[[PowerInsight], dict[str, float | None] | float | None]
+    transform_fn: Callable[[float], float] = lambda value: value
 
 
 @dataclass(frozen=True, kw_only=True)
 class PowerInsightIntegrationSensorDescription(SensorEntityDescription):
-    """Provide a description of a Heat pump Signal sensor."""
+    """Provide a description of a PowerInsight integration sensor."""
 
-    entities_fn: Callable[[dict], float | None]
-    exists_fn: Callable[[dict], bool] = lambda value: True
-    integration_value_fn: Callable[[dict], float | None]
-    transform_fn: Callable = lambda value: value
+    entities_fn: Callable[[PowerInsight], list[str]]
+    exists_fn: Callable[..., bool] = lambda _: True
+    integration_value_fn: Callable[[PowerInsight], dict[str, float | None] | float | None]
+    transform_fn: Callable[[float], float] = lambda value: value
 
 
-#
-# PowerInsight sensors
-#
+# ---------------------------------------------------------------------------
+# Hub-level sensors
+# ---------------------------------------------------------------------------
 
 POWER_INSIGHT_SENSORS = (
     PowerInsightSensorDescription(
@@ -86,7 +74,7 @@ POWER_INSIGHT_SENSORS = (
         suggested_display_precision=0,
         entities_fn=lambda obj: obj.source_entities_power,
         exists_fn=lambda options: options.check(CONF_ENABLE_DEBUG_ENTITIES),
-        value_fn=lambda obj: obj.total_power,
+        value_fn=lambda obj: obj.gross_power,
     ),
     PowerInsightSensorDescription(
         key="combined_export_ratio",
@@ -96,8 +84,7 @@ POWER_INSIGHT_SENSORS = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
         entities_fn=lambda obj: obj.source_entities_power,
-        # exists_fn=lambda options: options.check(),
-        value_fn=lambda obj: obj.export_share,
+        value_fn=lambda obj: obj.gross_power_export_ratio,
         transform_fn=lambda val: val * 100,
     ),
     PowerInsightSensorDescription(
@@ -111,7 +98,7 @@ POWER_INSIGHT_SENSORS = (
             obj.source_entities_price + obj.source_entities_power
         ),
         exists_fn=lambda options: options.check(CONF_CALCULATE_COST_RATES),
-        value_fn=lambda obj: obj.total_export_compensation_rate,
+        value_fn=lambda obj: obj.combined_export_compensation_rate,
     ),
     PowerInsightSensorDescription(
         key="combined_self_consumption_power",
@@ -121,8 +108,7 @@ POWER_INSIGHT_SENSORS = (
         device_class=SensorDeviceClass.POWER,
         suggested_display_precision=0,
         entities_fn=lambda obj: obj.source_entities_power,
-        # exists_fn=lambda options: adapter.exports_power,
-        value_fn=lambda obj: obj.self_consumption,
+        value_fn=lambda obj: obj.combined_consumption,
     ),
     PowerInsightSensorDescription(
         key="combined_self_consumption_ratio",
@@ -132,8 +118,7 @@ POWER_INSIGHT_SENSORS = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
         entities_fn=lambda obj: obj.source_entities_power,
-        # exists_fn=lambda options: adapter.exports_power,
-        value_fn=lambda obj: obj.self_consumption_share,
+        value_fn=lambda obj: obj.gross_power_consumption_ratio,
         transform_fn=lambda val: val * 100,
     ),
     PowerInsightSensorDescription(
@@ -147,7 +132,7 @@ POWER_INSIGHT_SENSORS = (
             obj.source_entities_price + obj.source_entities_power
         ),
         exists_fn=lambda options: options.check(CONF_CALCULATE_COST_SAVING_RATES),
-        value_fn=lambda obj: obj.total_self_cons_saving_rate,
+        value_fn=lambda obj: obj.combined_avoided_cost_rate,
     ),
     PowerInsightSensorDescription(
         key="combined_utilization_power",
@@ -157,8 +142,7 @@ POWER_INSIGHT_SENSORS = (
         device_class=SensorDeviceClass.POWER,
         suggested_display_precision=0,
         entities_fn=lambda obj: obj.source_entities_power,
-        # exists_fn=lambda options: adapter.exports_power,
-        value_fn=lambda obj: obj.utilization,
+        value_fn=lambda obj: obj.combined_utilization,
     ),
     PowerInsightSensorDescription(
         key="combined_utilization_ratio",
@@ -168,8 +152,7 @@ POWER_INSIGHT_SENSORS = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
         entities_fn=lambda obj: obj.source_entities_power,
-        # exists_fn=lambda options: adapter.exports_power,
-        value_fn=lambda obj: obj.utilization_share,
+        value_fn=lambda obj: obj.gross_power_utilization_ratio,
         transform_fn=lambda val: val * 100,
     ),
     PowerInsightSensorDescription(
@@ -182,8 +165,7 @@ POWER_INSIGHT_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        # exists_fn=lambda options: adapter.exports_power,
-        value_fn=lambda obj: obj.coe,
+        value_fn=lambda obj: obj.combined_coe,
     ),
     PowerInsightSensorDescription(
         key="combined_levelized_price_of_electricity",
@@ -195,8 +177,7 @@ POWER_INSIGHT_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        # exists_fn=lambda options: adapter.exports_power,
-        value_fn=lambda obj: obj.lcoe,
+        value_fn=lambda obj: obj.combined_lcoe,
     ),
     PowerInsightSensorDescription(
         key="combined_cost_rate",
@@ -207,9 +188,8 @@ POWER_INSIGHT_SENSORS = (
         suggested_display_precision=2,
         entities_fn=lambda obj: obj.source_entities_power,
         exists_fn=lambda options: options.check(CONF_CALCULATE_COST_RATES),
-        value_fn=lambda obj: obj.coe_rate,
+        value_fn=lambda obj: obj.combined_coe_rate,
     ),
-
     PowerInsightSensorDescription(
         key="combined_levelized_cost_rate",
         name="Combined levelized cost rate",
@@ -219,7 +199,7 @@ POWER_INSIGHT_SENSORS = (
         suggested_display_precision=2,
         entities_fn=lambda obj: obj.source_entities_power,
         exists_fn=lambda options: options.check(CONF_CALCULATE_LEVELIZED_COST_RATES),
-        value_fn=lambda obj: obj.lcoe_rate,
+        value_fn=lambda obj: obj.combined_lcoe_rate,
     ),
     PowerInsightSensorDescription(
         key="combined_operating_cost_rate",
@@ -232,7 +212,7 @@ POWER_INSIGHT_SENSORS = (
             obj.source_entities_price + obj.source_entities_power
         ),
         exists_fn=lambda options: options.check(CONF_CALCULATE_COST_RATES),
-        value_fn=lambda obj: obj.total_coo_rate,
+        value_fn=lambda obj: obj.combined_coo_rate,
     ),
     PowerInsightSensorDescription(
         key="combined_levelized_operating_cost_rate",
@@ -245,7 +225,7 @@ POWER_INSIGHT_SENSORS = (
             obj.source_entities_price + obj.source_entities_power
         ),
         exists_fn=lambda options: options.check(CONF_CALCULATE_LEVELIZED_COST_RATES),
-        value_fn=lambda obj: obj.total_lcoo_rate,
+        value_fn=lambda obj: obj.combined_lcoo_rate,
     ),
     PowerInsightSensorDescription(
         key="combined_cost_savings_rate",
@@ -258,7 +238,7 @@ POWER_INSIGHT_SENSORS = (
             obj.source_entities_price + obj.source_entities_power
         ),
         exists_fn=lambda options: options.check(CONF_CALCULATE_COST_SAVING_RATES),
-        value_fn=lambda obj: obj.total_saving_rate,
+        value_fn=lambda obj: obj.combined_saving_rate,
     ),
     PowerInsightSensorDescription(
         key="combined_levelized_cost_savings_rate",
@@ -271,10 +251,9 @@ POWER_INSIGHT_SENSORS = (
             obj.source_entities_price + obj.source_entities_power
         ),
         exists_fn=lambda options: options.check(CONF_CALCULATE_LEVELIZED_COST_SAVING_RATES),
-        value_fn=lambda obj: obj.total_levelized_saving_rate,
+        value_fn=lambda obj: obj.combined_levelized_saving_rate,
     ),
 )
-
 
 POWER_INSIGHT_INTEGRATION_SENSORS = (
     PowerInsightIntegrationSensorDescription(
@@ -288,7 +267,7 @@ POWER_INSIGHT_INTEGRATION_SENSORS = (
             obj.source_entities_price + obj.source_entities_power
         ),
         exists_fn=lambda options: options.check(CONF_ACCUMULATE_COST_RATES),
-        integration_value_fn=lambda obj: obj.total_export_compensation_rate,
+        integration_value_fn=lambda obj: obj.combined_export_compensation_rate,
     ),
     PowerInsightIntegrationSensorDescription(
         key="combined_total_operating_costs",
@@ -301,7 +280,7 @@ POWER_INSIGHT_INTEGRATION_SENSORS = (
             obj.source_entities_price + obj.source_entities_power
         ),
         exists_fn=lambda options: options.check(CONF_ACCUMULATE_COST_RATES),
-        integration_value_fn=lambda obj: obj.total_coo_rate,
+        integration_value_fn=lambda obj: obj.combined_coo_rate,
     ),
     PowerInsightIntegrationSensorDescription(
         key="combined_total_levelized_operating_costs",
@@ -314,7 +293,7 @@ POWER_INSIGHT_INTEGRATION_SENSORS = (
             obj.source_entities_price + obj.source_entities_power
         ),
         exists_fn=lambda options: options.check(CONF_ACCUMULATE_LEVELIZED_COST_RATES),
-        integration_value_fn=lambda obj: obj.total_lcoo_rate,
+        integration_value_fn=lambda obj: obj.combined_lcoo_rate,
     ),
     PowerInsightIntegrationSensorDescription(
         key="combined_total_self_consumption_cost_savings",
@@ -327,7 +306,7 @@ POWER_INSIGHT_INTEGRATION_SENSORS = (
             obj.source_entities_price + obj.source_entities_power
         ),
         exists_fn=lambda options: options.check(CONF_ACCUMULATE_COST_SAVING_RATES),
-        integration_value_fn=lambda obj: obj.total_self_cons_saving_rate,
+        integration_value_fn=lambda obj: obj.combined_avoided_cost_rate,
     ),
     PowerInsightIntegrationSensorDescription(
         key="combined_total_cost_savings",
@@ -340,7 +319,7 @@ POWER_INSIGHT_INTEGRATION_SENSORS = (
             obj.source_entities_price + obj.source_entities_power
         ),
         exists_fn=lambda options: options.check(CONF_ACCUMULATE_COST_SAVING_RATES),
-        integration_value_fn=lambda obj: obj.total_saving_rate,
+        integration_value_fn=lambda obj: obj.combined_saving_rate,
     ),
     PowerInsightIntegrationSensorDescription(
         key="combined_total_levelized_cost_savings",
@@ -353,31 +332,78 @@ POWER_INSIGHT_INTEGRATION_SENSORS = (
             obj.source_entities_price + obj.source_entities_power
         ),
         exists_fn=lambda options: options.check(CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES),
-        integration_value_fn=lambda obj: obj.total_levelized_saving_rate,
+        integration_value_fn=lambda obj: obj.combined_levelized_saving_rate,
     ),
 )
 
 
+# ---------------------------------------------------------------------------
+# Grid adapter sensors
+# ---------------------------------------------------------------------------
 
 POWER_INSIGHT_GRID_ADAPTER_SENSORS = (
-    # PowerInsightSensorDescription(
-    #     key="self_consumption_rate",
-    #     name="Self consumption rate",
-    #     icon="mdi:percent",
-    #     native_unit_of_measurement=PERCENTAGE,
-    #     state_class=SensorStateClass.MEASUREMENT,
-    #     suggested_display_precision=0,
-    #     entities_fn=lambda obj: obj.source_entities_power,
-    #     value_fn=lambda obj: obj.grid_adapter_self_cons_rates,
-    #     transform_fn=lambda val: val * 100,
-    # ),
+    PowerInsightSensorDescription(
+        key="import_power",
+        name="Import power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        suggested_display_precision=0,
+        entities_fn=lambda obj: obj.source_entities_power,
+        value_fn=lambda obj: obj.grid_adapters_import_power,
+    ),
+    PowerInsightSensorDescription(
+        key="export_power",
+        name="Export power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        suggested_display_precision=0,
+        entities_fn=lambda obj: obj.source_entities_power,
+        value_fn=lambda obj: obj.grid_adapters_export_power,
+    ),
+    PowerInsightSensorDescription(
+        key="export_ratio",
+        name="Export ratio",
+        icon="mdi:percent",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        entities_fn=lambda obj: obj.source_entities_power,
+        value_fn=lambda obj: obj.grid_adapters_export_ratio,
+        transform_fn=lambda val: val * 100,
+    ),
+    PowerInsightSensorDescription(
+        key="cost_rate",
+        name="Cost rate",
+        icon="mdi:currency-eur",
+        native_unit_of_measurement="EUR/h",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: obj.source_entities_price + obj.source_entities_power,
+        exists_fn=lambda options: options.check(CONF_CALCULATE_COST_RATES),
+        value_fn=lambda obj: obj.grid_adapters_coe_rate,
+    ),
+)
+
+POWER_INSIGHT_GRID_ADAPTER_INTEGRATION_SENSORS = (
+    PowerInsightIntegrationSensorDescription(
+        key="total_cost",
+        name="Total cost",
+        native_unit_of_measurement="EUR",
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: obj.source_entities_price + obj.source_entities_power,
+        exists_fn=lambda options: options.check(CONF_ACCUMULATE_COST_RATES),
+        integration_value_fn=lambda obj: obj.grid_adapters_coe_rate,
+    ),
 )
 
 
-
-#
-# PowerInsight production adapter sensors
-#
+# ---------------------------------------------------------------------------
+# Production adapter sensors (PV + Battery — shared)
+# ---------------------------------------------------------------------------
 
 POWER_INSIGHT_PROD_ADAPTER_SENSORS = (
     PowerInsightSensorDescription(
@@ -386,7 +412,6 @@ POWER_INSIGHT_PROD_ADAPTER_SENSORS = (
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.POWER,
-        suggested_unit_of_measurement=UnitOfPower.WATT,
         suggested_display_precision=0,
         entities_fn=lambda obj: obj.source_entities_power,
         exists_fn=lambda adapter: adapter.exports_power,
@@ -401,7 +426,7 @@ POWER_INSIGHT_PROD_ADAPTER_SENSORS = (
         suggested_display_precision=0,
         entities_fn=lambda obj: obj.source_entities_power,
         exists_fn=lambda adapter: adapter.exports_power,
-        value_fn=lambda obj: obj.prod_adapters_export_rates,
+        value_fn=lambda obj: obj.prod_adapters_export_ratios,
         transform_fn=lambda val: val * 100,
     ),
     PowerInsightSensorDescription(
@@ -435,10 +460,9 @@ POWER_INSIGHT_PROD_ADAPTER_SENSORS = (
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.POWER,
-        suggested_unit_of_measurement=UnitOfPower.WATT,
         suggested_display_precision=0,
         entities_fn=lambda obj: obj.source_entities_power,
-        value_fn=lambda obj: obj.prod_adapters_self_cons_power,
+        value_fn=lambda obj: obj.prod_adapters_consumption_power,
     ),
     PowerInsightSensorDescription(
         key="self_consumption_ratio",
@@ -448,7 +472,7 @@ POWER_INSIGHT_PROD_ADAPTER_SENSORS = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
         entities_fn=lambda obj: obj.source_entities_power,
-        value_fn=lambda obj: obj.prod_adapters_self_cons_rates,
+        value_fn=lambda obj: obj.prod_adapters_consumption_ratios,
         transform_fn=lambda val: val * 100,
     ),
     PowerInsightSensorDescription(
@@ -459,7 +483,7 @@ POWER_INSIGHT_PROD_ADAPTER_SENSORS = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
         entities_fn=lambda obj: obj.source_entities_power,
-        value_fn=lambda obj: obj.prod_adapters_self_cons_shares,
+        value_fn=lambda obj: obj.prod_adapters_consumption_shares,
         transform_fn=lambda val: val * 100,
     ),
     PowerInsightSensorDescription(
@@ -472,7 +496,7 @@ POWER_INSIGHT_PROD_ADAPTER_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        value_fn=lambda obj: obj.prod_adapters_self_cons_saving_rates,
+        value_fn=lambda obj: obj.prod_adapters_avoided_cost_rates,
     ),
     PowerInsightSensorDescription(
         key="operating_cost_rate",
@@ -508,7 +532,7 @@ POWER_INSIGHT_PROD_ADAPTER_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        value_fn=lambda obj: obj.prod_adapters_saving_rates,
+        value_fn=lambda obj: obj.prod_adapters_cost_saving_rates,
     ),
     PowerInsightSensorDescription(
         key="levelized_cost_savings_rate",
@@ -520,10 +544,9 @@ POWER_INSIGHT_PROD_ADAPTER_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        value_fn=lambda obj: obj.prod_adapters_levelized_saving_rates,
+        value_fn=lambda obj: obj.prod_adapters_levelized_cost_saving_rates,
     ),
 )
-
 
 POWER_INSIGHT_PROD_ADAPTER_INTEGRATION_SENSORS = (
     PowerInsightIntegrationSensorDescription(
@@ -550,7 +573,6 @@ POWER_INSIGHT_PROD_ADAPTER_INTEGRATION_SENSORS = (
             obj.source_entities_price + obj.source_entities_power
         ),
         integration_value_fn=lambda obj: obj.prod_adapters_coo_rates,
-
     ),
     PowerInsightIntegrationSensorDescription(
         key="total_levelized_operating_costs",
@@ -574,7 +596,7 @@ POWER_INSIGHT_PROD_ADAPTER_INTEGRATION_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        integration_value_fn=lambda obj: obj.prod_adapters_self_cons_saving_rates,
+        integration_value_fn=lambda obj: obj.prod_adapters_avoided_cost_rates,
     ),
     PowerInsightIntegrationSensorDescription(
         key="total_cost_savings",
@@ -586,7 +608,7 @@ POWER_INSIGHT_PROD_ADAPTER_INTEGRATION_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        integration_value_fn=lambda obj: obj.prod_adapters_saving_rates,
+        integration_value_fn=lambda obj: obj.prod_adapters_cost_saving_rates,
     ),
     PowerInsightIntegrationSensorDescription(
         key="total_levelized_cost_savings",
@@ -598,22 +620,27 @@ POWER_INSIGHT_PROD_ADAPTER_INTEGRATION_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        integration_value_fn=lambda obj: obj.prod_adapters_levelized_saving_rates,
+        integration_value_fn=lambda obj: obj.prod_adapters_levelized_cost_saving_rates,
     ),
 )
 
 
-#
-# PowerInsight consumption adapter sensors
-#
+# ---------------------------------------------------------------------------
+# Battery-specific sensors (in addition to POWER_INSIGHT_PROD_ADAPTER_SENSORS)
+# ---------------------------------------------------------------------------
 
-# consumption
-# Power from grid, pv, ...
-# total power from grid, pv, ...
+# Charging source share sensors are created dynamically per battery in
+# async_setup_entry, one per power-providing adapter, using
+# storage_adapters_charging_source_shares.
+POWER_INSIGHT_BATTERY_ADAPTER_SENSORS: tuple[PowerInsightSensorDescription, ...] = ()
+POWER_INSIGHT_BATTERY_ADAPTER_INTEGRATION_SENSORS: tuple[
+    PowerInsightIntegrationSensorDescription, ...
+] = ()
 
-# total consumption
-# grid, pv,... shares
 
+# ---------------------------------------------------------------------------
+# Consumer adapter sensors
+# ---------------------------------------------------------------------------
 
 POWER_INSIGHT_CONS_ADAPTER_SENSORS = (
     PowerInsightSensorDescription(
@@ -629,8 +656,8 @@ POWER_INSIGHT_CONS_ADAPTER_SENSORS = (
         value_fn=lambda obj: obj.cons_adapters_coo_rates,
     ),
     PowerInsightSensorDescription(
-        key="operating_cost_rate_levelized",
-        name="Operating cost rate levelized",
+        key="levelized_operating_cost_rate",
+        name="Levelized operating cost rate",
         icon="mdi:currency-eur",
         native_unit_of_measurement="EUR/h",
         state_class=SensorStateClass.MEASUREMENT,
@@ -642,20 +669,23 @@ POWER_INSIGHT_CONS_ADAPTER_SENSORS = (
     ),
 )
 
+POWER_INSIGHT_CONS_ADAPTER_INTEGRATION_SENSORS: tuple[
+    PowerInsightIntegrationSensorDescription, ...
+] = ()
 
-POWER_INSIGHT_CONS_ADAPTER_INTEGRATION_SENSORS = ()
 
-
-
-
+# ---------------------------------------------------------------------------
+# Options wrapper
+# ---------------------------------------------------------------------------
 
 
 class OptionsWrapper:
     """Wrapper around the raw options dict providing a unified check interface."""
 
     def __init__(self, options: dict) -> None:
+        """Initialise from the raw options dict."""
         self._options = options
-        self._selected: set = set()
+        self._selected: set[str] = set()
         for key, value in options.items():
             if isinstance(value, list):
                 self._selected.update(value)
@@ -667,153 +697,228 @@ class OptionsWrapper:
         return bool(self._options.get(key, False))
 
 
+# ---------------------------------------------------------------------------
+# Platform setup
+# ---------------------------------------------------------------------------
 
 
 async def async_setup_entry(
         hass: HomeAssistant,
         entry: MyConfigEntry,
-        async_add_entities: AddEntitiesCallback
+        async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
     power_insight = entry.runtime_data.power_insight
-    entities = []
-
     options_wrapped = OptionsWrapper(entry.options)
 
+    # --- Hub-level sensors ---
+    entities: list = []
     for description in POWER_INSIGHT_SENSORS:
         if not description.exists_fn(options_wrapped):
             continue
-        
-        entity = PowerInsightSensor(
+        entities.append(PowerInsightSensor(
             description=description,
             config_entry=entry,
             source_entities=description.entities_fn(power_insight),
             power_insight=power_insight,
-        )
-        entities.append(entity)
+        ))
 
     for description in POWER_INSIGHT_INTEGRATION_SENSORS:
         if not description.exists_fn(options_wrapped):
             continue
-
-        entity = PowerInsightIntegrationSensor(
+        entities.append(PowerInsightIntegrationSensor(
             description=description,
             config_entry=entry,
             source_entities=description.entities_fn(power_insight),
             power_insight=power_insight,
-        )
-        entities.append(entity)
+        ))
 
     async_add_entities(entities)
 
-
+    # --- Grid adapter sensors ---
     grid_adapter = power_insight.grid_adapter
     entities = []
     for description in POWER_INSIGHT_GRID_ADAPTER_SENSORS:
-        entity = PowerInsightAdapterSensor(
+        if not description.exists_fn(options_wrapped):
+            continue
+        entities.append(PowerInsightAdapterSensor(
             description=description,
             config_entry=entry,
             source_entities=description.entities_fn(power_insight),
             power_insight=power_insight,
             device_adapter=grid_adapter,
-        )
-        entities.append(entity)
-    
+        ))
+
+    for description in POWER_INSIGHT_GRID_ADAPTER_INTEGRATION_SENSORS:
+        if not description.exists_fn(options_wrapped):
+            continue
+        entities.append(PowerInsightAdapterIntegrationSensor(
+            description=description,
+            config_entry=entry,
+            source_entities=description.entities_fn(power_insight),
+            power_insight=power_insight,
+            device_adapter=grid_adapter,
+        ))
+
     async_add_entities(entities, config_subentry_id=grid_adapter.uid)
 
-
-    for adapter in power_insight.prod_adapters:
+    # --- PV adapter sensors ---
+    for adapter in power_insight.pv_system_adapters:
         entities = []
         for description in POWER_INSIGHT_PROD_ADAPTER_SENSORS:
             if not description.exists_fn(adapter):
                 continue
-
-            entity = PowerInsightAdapterSensor(
+            entities.append(PowerInsightAdapterSensor(
                 description=description,
                 config_entry=entry,
                 source_entities=description.entities_fn(power_insight),
                 power_insight=power_insight,
                 device_adapter=adapter,
-            )
-            entities.append(entity)
+            ))
 
         for description in POWER_INSIGHT_PROD_ADAPTER_INTEGRATION_SENSORS:
             if not description.exists_fn(adapter):
                 continue
-
-            entity = PowerInsightAdapterIntegrationSensor(
+            entities.append(PowerInsightAdapterIntegrationSensor(
                 description=description,
                 config_entry=entry,
                 source_entities=description.entities_fn(power_insight),
                 power_insight=power_insight,
                 device_adapter=adapter,
-            )
-            entities.append(entity)
+            ))
 
         async_add_entities(entities, config_subentry_id=adapter.uid)
 
-    for adapter in power_insight.cons_adapters:
+    # --- Battery adapter sensors ---
+    for adapter in power_insight.storage_adapters:
         entities = []
-        for description in POWER_INSIGHT_CONS_ADAPTER_SENSORS:
+
+        # Shared production adapter sensors
+        for description in POWER_INSIGHT_PROD_ADAPTER_SENSORS:
             if not description.exists_fn(adapter):
                 continue
-
-            entity = PowerInsightAdapterSensor(
+            entities.append(PowerInsightAdapterSensor(
                 description=description,
                 config_entry=entry,
                 source_entities=description.entities_fn(power_insight),
                 power_insight=power_insight,
                 device_adapter=adapter,
-            )
-            entities.append(entity)
+            ))
 
-        for description in POWER_INSIGHT_CONS_ADAPTER_INTEGRATION_SENSORS:
+        for description in POWER_INSIGHT_PROD_ADAPTER_INTEGRATION_SENSORS:
             if not description.exists_fn(adapter):
                 continue
-
-            entity = PowerInsightAdapterIntegrationSensor(
+            entities.append(PowerInsightAdapterIntegrationSensor(
                 description=description,
                 config_entry=entry,
                 source_entities=description.entities_fn(power_insight),
                 power_insight=power_insight,
                 device_adapter=adapter,
-            )
-            entities.append(entity)
+            ))
 
+        # Battery-specific static sensors
+        for description in POWER_INSIGHT_BATTERY_ADAPTER_SENSORS:
+            if not description.exists_fn(adapter):
+                continue
+            entities.append(PowerInsightAdapterSensor(
+                description=description,
+                config_entry=entry,
+                source_entities=description.entities_fn(power_insight),
+                power_insight=power_insight,
+                device_adapter=adapter,
+            ))
 
-        for power_adapter in power_insight.power_providing_adapters:
+        for description in POWER_INSIGHT_BATTERY_ADAPTER_INTEGRATION_SENSORS:
+            if not description.exists_fn(adapter):
+                continue
+            entities.append(PowerInsightAdapterIntegrationSensor(
+                description=description,
+                config_entry=entry,
+                source_entities=description.entities_fn(power_insight),
+                power_insight=power_insight,
+                device_adapter=adapter,
+            ))
 
-            name = power_adapter.verbose_name
-
-
+        # Dynamic charging source share sensors — one per power-providing adapter
+        for source_adapter in power_insight.gross_power_adapters:
+            name = source_adapter.verbose_name
             dynamic_description = PowerInsightSensorDescription(
-                key=f"{name}_ratio",
-                name=f"{name} Ratio",
+                key=f"charging_share_from_{name}",
+                name=f"Charging share from {name}",
                 icon="mdi:percent",
                 native_unit_of_measurement=PERCENTAGE,
                 state_class=SensorStateClass.MEASUREMENT,
                 suggested_display_precision=0,
-                entities_fn=lambda obj: (
-                    obj.source_entities_power
-                ),
-                value_fn=lambda obj: obj.cons_adapters_source_shares,
+                entities_fn=lambda obj: obj.source_entities_power,
+                value_fn=lambda obj: obj.storage_adapters_charging_source_shares,
                 transform_fn=lambda val: val * 100,
             )
-
-            if not description.exists_fn(adapter):
-                continue
-
-            entity = PowerInsightDynamicAdapterSensor(
+            entities.append(PowerInsightDynamicAdapterSensor(
                 description=dynamic_description,
                 config_entry=entry,
                 source_entities=dynamic_description.entities_fn(power_insight),
                 power_insight=power_insight,
                 device_adapter=adapter,
-                dynamic_adapter=power_adapter,
-            )
-            entities.append(entity)
+                dynamic_adapter=source_adapter,
+            ))
 
         async_add_entities(entities, config_subentry_id=adapter.uid)
+
+    # --- Consumer adapter sensors ---
+    for adapter in power_insight.consumer_adapters:
+        entities = []
+
+        for description in POWER_INSIGHT_CONS_ADAPTER_SENSORS:
+            if not description.exists_fn(adapter):
+                continue
+            entities.append(PowerInsightAdapterSensor(
+                description=description,
+                config_entry=entry,
+                source_entities=description.entities_fn(power_insight),
+                power_insight=power_insight,
+                device_adapter=adapter,
+            ))
+
+        for description in POWER_INSIGHT_CONS_ADAPTER_INTEGRATION_SENSORS:
+            if not description.exists_fn(adapter):
+                continue
+            entities.append(PowerInsightAdapterIntegrationSensor(
+                description=description,
+                config_entry=entry,
+                source_entities=description.entities_fn(power_insight),
+                power_insight=power_insight,
+                device_adapter=adapter,
+            ))
+
+        # Dynamic consumption source share sensors — one per power-providing adapter
+        for source_adapter in power_insight.gross_power_adapters:
+            name = source_adapter.verbose_name
+            dynamic_description = PowerInsightSensorDescription(
+                key=f"{name}_ratio",
+                name=f"{name} ratio",
+                icon="mdi:percent",
+                native_unit_of_measurement=PERCENTAGE,
+                state_class=SensorStateClass.MEASUREMENT,
+                suggested_display_precision=0,
+                entities_fn=lambda obj: obj.source_entities_power,
+                value_fn=lambda obj: obj.cons_adapters_source_shares,
+                transform_fn=lambda val: val * 100,
+            )
+            entities.append(PowerInsightDynamicAdapterSensor(
+                description=dynamic_description,
+                config_entry=entry,
+                source_entities=dynamic_description.entities_fn(power_insight),
+                power_insight=power_insight,
+                device_adapter=adapter,
+                dynamic_adapter=source_adapter,
+            ))
+
+        async_add_entities(entities, config_subentry_id=adapter.uid)
+
+
+# ---------------------------------------------------------------------------
+# Sensor entity classes
+# ---------------------------------------------------------------------------
 
 
 class BasePowerInsightSensor(BaseEventSensorEntity):
@@ -825,7 +930,7 @@ class BasePowerInsightSensor(BaseEventSensorEntity):
 
     def __init__(
             self,
-            description: SensorEntityDescription,
+            description: PowerInsightSensorDescription,
             config_entry: ConfigEntry,
             source_entities: list[str],
             power_insight: PowerInsight,
@@ -837,19 +942,17 @@ class BasePowerInsightSensor(BaseEventSensorEntity):
 
 
 class PowerInsightSensor(BasePowerInsightSensor):
-    """Sensor entity with access to the `PowerInsight` instance."""
+    """Hub-level sensor reading directly from PowerInsight."""
 
     def __init__(
             self,
-            description: SensorEntityDescription,
+            description: PowerInsightSensorDescription,
             config_entry: ConfigEntry,
             source_entities: list[str],
             power_insight: PowerInsight,
     ) -> None:
         """Initialize sensor entity."""
-        super().__init__(
-            description, config_entry, source_entities, power_insight
-        )
+        super().__init__(description, config_entry, source_entities, power_insight)
         self._attr_unique_id = (
             f"{self.config_entry.entry_id}_{self.entity_description.key}"
         )
@@ -862,41 +965,29 @@ class PowerInsightSensor(BasePowerInsightSensor):
     @property
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
-        data = self.power_insight
-        assert data is not None
-        value = self.entity_description.value_fn(data)
+        value = self.entity_description.value_fn(self.power_insight)
         if value is not None:
             value = self.entity_description.transform_fn(value)
-
         return value
 
 
 class PowerInsightAdapterSensor(BasePowerInsightSensor):
-    """Sensor entity with access to the `Adapter` instance.
-
-    Used for adapter sensors entities that require
-    additional access to the `PowerInsight` instance.
-
-    """
+    """Per-adapter sensor that extracts its value from a uid-keyed dict."""
 
     def __init__(
             self,
-            description: SensorEntityDescription,
+            description: PowerInsightSensorDescription,
             config_entry: ConfigEntry,
             source_entities: list[str],
             power_insight: PowerInsight,
-            device_adapter,
+            device_adapter: AbstractBaseAdapter,
     ) -> None:
-        """Initialize device sensor entity."""
-        super().__init__(
-            description, config_entry, source_entities, power_insight
-        )
+        """Initialize adapter sensor entity."""
+        super().__init__(description, config_entry, source_entities, power_insight)
         self.device_adapter = device_adapter
 
         uid = f"{self.config_entry.entry_id}_{self.device_adapter.uid}"
-
         self._attr_unique_id = f"{uid}_{self.entity_description.key}"
-
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self.device_adapter.uid)},
@@ -906,44 +997,36 @@ class PowerInsightAdapterSensor(BasePowerInsightSensor):
     @property
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
-        assert self.power_insight is not None
         value = self.entity_description.value_fn(self.power_insight)
         value = get_value(self.device_adapter.uid, value)
         if value is not None:
             value = self.entity_description.transform_fn(value)
-
         return value
 
 
-
 class PowerInsightDynamicAdapterSensor(BasePowerInsightSensor):
-    """Sensor entity with access to the `Adapter` instance.
+    """Per-adapter sensor that extracts its value from a nested uid-keyed dict.
 
-    Used for adapter sensors entities that require
-    additional access to the `PowerInsight` instance.
-
+    Used for sensors where the result depends on two adapters:
+    ``value_fn`` returns ``{device_adapter_uid: {dynamic_adapter_uid: value}}``.
     """
 
     def __init__(
             self,
-            description: SensorEntityDescription,
+            description: PowerInsightSensorDescription,
             config_entry: ConfigEntry,
             source_entities: list[str],
             power_insight: PowerInsight,
-            device_adapter,
-            dynamic_adapter
+            device_adapter: AbstractBaseAdapter,
+            dynamic_adapter: AbstractBaseAdapter,
     ) -> None:
-        """Initialize device sensor entity."""
-        super().__init__(
-            description, config_entry, source_entities, power_insight
-        )
+        """Initialize dynamic adapter sensor entity."""
+        super().__init__(description, config_entry, source_entities, power_insight)
         self.device_adapter = device_adapter
         self.dynamic_adapter = dynamic_adapter
 
         uid = f"{self.config_entry.entry_id}_{self.device_adapter.uid}"
-
         self._attr_unique_id = f"{uid}_{self.entity_description.key}"
-
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self.device_adapter.uid)},
@@ -953,20 +1036,21 @@ class PowerInsightDynamicAdapterSensor(BasePowerInsightSensor):
     @property
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
-        assert self.power_insight is not None
         value = self.entity_description.value_fn(self.power_insight)
         value = get_value(self.device_adapter.uid, value)
         value = get_value(self.dynamic_adapter.uid, value)
         if value is not None:
             value = self.entity_description.transform_fn(value)
-
         return value
 
 
+# ---------------------------------------------------------------------------
+# Integration sensor entity classes
+# ---------------------------------------------------------------------------
 
 
 class BasePowerInsightIntegrationSensor(BaseEventIntegrationSensorEntity):
-    """Integration sensor entity with access to the `PowerInsight` instance."""
+    """Base integration sensor entity."""
 
     entity_description: PowerInsightIntegrationSensorDescription
 
@@ -974,32 +1058,29 @@ class BasePowerInsightIntegrationSensor(BaseEventIntegrationSensorEntity):
 
     def __init__(
             self,
-            description: SensorEntityDescription,
+            description: PowerInsightIntegrationSensorDescription,
             config_entry: ConfigEntry,
             source_entities: list[str],
             power_insight: PowerInsight,
     ) -> None:
-        """Initialize the base sensor entity."""
+        """Initialize the base integration sensor entity."""
         super().__init__(source_entities, power_insight)
         self.entity_description = description
         self.config_entry = config_entry
 
 
 class PowerInsightIntegrationSensor(BasePowerInsightIntegrationSensor):
-    """Integration sensor entity with access to the `PowerInsight` instance."""
+    """Hub-level integration sensor."""
 
     def __init__(
             self,
-            description: SensorEntityDescription,
+            description: PowerInsightIntegrationSensorDescription,
             config_entry: ConfigEntry,
             source_entities: list[str],
             power_insight: PowerInsight,
     ) -> None:
-
-        super().__init__(
-            description, config_entry, source_entities, power_insight
-        )
-
+        """Initialize the integration sensor entity."""
+        super().__init__(description, config_entry, source_entities, power_insight)
         self._attr_unique_id = (
             f"{self.config_entry.entry_id}_{self.entity_description.key}"
         )
@@ -1011,37 +1092,30 @@ class PowerInsightIntegrationSensor(BasePowerInsightIntegrationSensor):
 
     @property
     def integration_value(self) -> float | None:
-        """Return the state of the sensor."""
-        data = self.power_insight
-        assert data is not None
-        value = self.entity_description.integration_value_fn(data)
+        """Return the current rate value to integrate."""
+        value = self.entity_description.integration_value_fn(self.power_insight)
         if value is not None:
             value = self.entity_description.transform_fn(value)
-
         return value
 
 
 class PowerInsightAdapterIntegrationSensor(BasePowerInsightIntegrationSensor):
-    """Integration sensor entity with access to the `PowerInsight` instance."""
+    """Per-adapter integration sensor that extracts its value from a uid-keyed dict."""
 
     def __init__(
             self,
-            description: SensorEntityDescription,
+            description: PowerInsightIntegrationSensorDescription,
             config_entry: ConfigEntry,
             source_entities: list[str],
             power_insight: PowerInsight,
-            device_adapter,
+            device_adapter: AbstractBaseAdapter,
     ) -> None:
-
-        super().__init__(
-            description, config_entry, source_entities, power_insight
-        )
+        """Initialize the adapter integration sensor entity."""
+        super().__init__(description, config_entry, source_entities, power_insight)
         self.device_adapter = device_adapter
 
         uid = f"{self.config_entry.entry_id}_{self.device_adapter.uid}"
-
         self._attr_unique_id = f"{uid}_{self.entity_description.key}"
-
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self.device_adapter.uid)},
@@ -1050,12 +1124,9 @@ class PowerInsightAdapterIntegrationSensor(BasePowerInsightIntegrationSensor):
 
     @property
     def integration_value(self) -> float | None:
-        """Return the state of the sensor."""
-        data = self.power_insight
-        assert data is not None
-        value = self.entity_description.integration_value_fn(data)
+        """Return the current rate value to integrate."""
+        value = self.entity_description.integration_value_fn(self.power_insight)
         value = get_value(self.device_adapter.uid, value)
         if value is not None:
             value = self.entity_description.transform_fn(value)
-
         return value


### PR DESCRIPTION
## Summary
This PR refactors the sensor platform to align with updated PowerInsight API method names and improves code organization, documentation, and type hints throughout the sensor definitions and entity classes.

## Key Changes

### Sensor Definition Updates
- **Renamed sensor value functions** to match updated PowerInsight API:
  - `total_power` → `gross_power`
  - `export_share` → `gross_power_export_ratio`
  - `self_consumption` → `combined_consumption`
  - `self_consumption_share` → `gross_power_consumption_ratio`
  - `utilization` → `combined_utilization`
  - `utilization_share` → `gross_power_utilization_ratio`
  - `coe` → `combined_coe`, `coe_rate` → `combined_coe_rate`
  - `lcoe` → `combined_lcoe`, `lcoe_rate` → `combined_lcoe_rate`
  - `total_coo_rate` → `combined_coo_rate`, `total_lcoo_rate` → `combined_lcoo_rate`
  - `total_saving_rate` → `combined_saving_rate`, `total_levelized_saving_rate` → `combined_levelized_saving_rate`
  - `total_export_compensation_rate` → `combined_export_compensation_rate`
  - `total_self_cons_saving_rate` → `combined_avoided_cost_rate`
  - `prod_adapters_export_rates` → `prod_adapters_export_ratios`
  - `prod_adapters_self_cons_*` → `prod_adapters_consumption_*`
  - `prod_adapters_saving_rates` → `prod_adapters_cost_saving_rates`
  - `prod_adapters_levelized_saving_rates` → `prod_adapters_levelized_cost_saving_rates`

### New Grid Adapter Sensors
- Added `import_power`, `export_power`, `export_ratio`, and `cost_rate` sensors for grid adapter
- Added integration sensor for grid adapter total cost accumulation

### Code Organization
- Reorganized sensor definitions with clear section headers (Hub-level, Grid adapter, Production adapter, Battery, Consumer)
- Improved docstrings for sensor description dataclasses
- Added comprehensive comments explaining battery and consumer dynamic sensor generation

### Type Hints and Documentation
- Enhanced type hints in `PowerInsightSensorDescription` and `PowerInsightIntegrationSensorDescription`:
  - `entities_fn: Callable[[PowerInsight], list[str]]`
  - `value_fn: Callable[[PowerInsight], dict[str, float | None] | float | None]`
  - `transform_fn: Callable[[float], float]`
- Improved docstrings for sensor entity classes
- Added `AbstractBaseAdapter` import for better type safety

### Sensor Entity Classes
- Renamed `PowerInsightAdapterSensor` docstring from "device sensor" to "adapter sensor"
- Improved `PowerInsightDynamicAdapterSensor` documentation explaining nested dict extraction
- Simplified `native_value` and `integration_value` property implementations by removing unnecessary assertions
- Updated consumer adapter sensor key from `operating_cost_rate_levelized` to `levelized_operating_cost_rate`

### Battery Adapter Handling
- Refactored battery adapter setup to use shared production adapter sensors plus battery-specific sensors
- Implemented dynamic charging source share sensors (one per power-providing adapter)
- Improved code clarity with explicit sensor grouping

### PowerInsight API Additions
- Added `combined_utilization` property (sum of charging and standby power)
- Added `gross_power_utilization_ratio` property
- Added grid adapter properties: `grid_adapters_import_power`, `grid_adapters_export_power`, `grid_adapters_export_ratio`, `grid_adapters_coe_rate`
- Fixed bug in `storage_adapters_charging_shares` where loop variable was incorrectly used

### Cleanup
- Removed unused imports (`CURRENCY_EURO`, `UnitOfEnergy`, `UnitOfTime`, `

https://claude.ai/code/session_01E1BQtWEn15L29iim9MnCaq