### PR TITLE
Add correction factor for levelized costs and simplify config flow

### DIFF
--- a/custom_components/power_insight/__init__.py
+++ b/custom_components/power_insight/__init__.py
@@ -2,16 +2,14 @@
 
 import logging
 from dataclasses import dataclass
-from datetime import UTC, datetime
 
-from homeassistant.config_entries import ConfigEntry, ConfigSubentry
-from homeassistant.helpers import issue_registry as ir, entity_registry as er
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.const import STATE_UNAVAILABLE
 
 from .const import (
     CONF_CHARGE_FROM_ADAPTERS,
-    CONF_RETIRED_ADAPTERS,
     DOMAIN,
     PLATFORMS,
 )
@@ -151,91 +149,6 @@ async def async_unload_entry(
     event_handler.untrack_entities()
 
     return unload
-
-
-# Per-adapter levelized accumulated sensor keys whose final value is frozen
-# into the retired-adapter ledger on removal (see sensor.py).
-LEVELIZED_TOTAL_KEYS = (
-    "total_levelized_operating_costs",
-    "total_levelized_cost_savings",
-)
-
-
-def _snapshot_retired_adapter(
-    hass: HomeAssistant,
-    entry: MyConfigEntry,
-    subentry: ConfigSubentry,
-) -> None:
-    """Freeze a removed PV/battery adapter's levelized totals into the ledger.
-
-    The per-adapter accumulated sensors already display ``base × correction``,
-    so snapshotting their live state captures the final corrected contribution.
-    This keeps the combined levelized totals from dropping when an end-of-life
-    device is removed.
-    """
-    ent_reg = er.async_get(hass)
-    totals: dict[str, float] = {}
-    for key in LEVELIZED_TOTAL_KEYS:
-        unique_id = f"{entry.entry_id}_{subentry.subentry_id}_{key}"
-        entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, unique_id)
-        if entity_id is None:
-            continue
-        state = hass.states.get(entity_id)
-        if state is None or state.state in (STATE_UNAVAILABLE, "unknown"):
-            continue
-        try:
-            totals[key] = float(state.state)
-        except (ValueError, TypeError):
-            continue
-
-    if not totals:
-        return
-
-    ledger = list(entry.data.get(CONF_RETIRED_ADAPTERS, []))
-    ledger.append(
-        {
-            "subentry_id": subentry.subentry_id,
-            "adapter_type": subentry.data.get("adapter", {}).get("adapter_type"),
-            "title": subentry.title,
-            "retired_at": datetime.now(UTC).isoformat(),
-            "totals": totals,
-        }
-    )
-    hass.config_entries.async_update_entry(
-        entry, data={**entry.data, CONF_RETIRED_ADAPTERS: ledger}
-    )
-
-
-async def async_remove_subentry(
-    hass: HomeAssistant,
-    entry: MyConfigEntry,
-    subentry: ConfigSubentry,
-) -> None:
-    """Snapshot retired levelized totals and raise battery repair issues."""
-    removed_type = subentry.data.get("adapter", {}).get("adapter_type")
-
-    # Freeze a removed end-of-life PV/battery adapter's contribution.
-    if removed_type in ("pv_system", "battery"):
-        _snapshot_retired_adapter(hass, entry, subentry)
-
-    if removed_type not in ("grid", "pv_system"):
-        return
-
-    removed_id = subentry.subentry_id
-    for remaining in entry.subentries.values():
-        if remaining.data.get("adapter", {}).get("adapter_type") != "battery":
-            continue
-        charge_from = remaining.data["adapter"]["config"].get(CONF_CHARGE_FROM_ADAPTERS, [])
-        if removed_id in charge_from:
-            ir.async_create_issue(
-                hass,
-                DOMAIN,
-                f"reconfigure_battery_{remaining.subentry_id}",
-                is_fixable=False,
-                severity=ir.IssueSeverity.WARNING,
-                translation_key="reconfigure_battery_adapters",
-                translation_placeholders={"battery_name": remaining.title},
-            )
 
 
 async def async_migrate_entry(

--- a/custom_components/power_insight/__init__.py
+++ b/custom_components/power_insight/__init__.py
@@ -2,13 +2,19 @@
 
 import logging
 from dataclasses import dataclass
+from datetime import UTC, datetime
 
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
-from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers import issue_registry as ir, entity_registry as er
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.const import STATE_UNAVAILABLE
 
-from .const import CONF_CHARGE_FROM_ADAPTERS, DOMAIN, PLATFORMS
+from .const import (
+    CONF_CHARGE_FROM_ADAPTERS,
+    CONF_RETIRED_ADAPTERS,
+    DOMAIN,
+    PLATFORMS,
+)
 from .utils import state_to_value
 from .power_insight import PowerInsight
 from .event_handler import EventHandler
@@ -147,13 +153,71 @@ async def async_unload_entry(
     return unload
 
 
+# Per-adapter levelized accumulated sensor keys whose final value is frozen
+# into the retired-adapter ledger on removal (see sensor.py).
+LEVELIZED_TOTAL_KEYS = (
+    "total_levelized_operating_costs",
+    "total_levelized_cost_savings",
+)
+
+
+def _snapshot_retired_adapter(
+    hass: HomeAssistant,
+    entry: MyConfigEntry,
+    subentry: ConfigSubentry,
+) -> None:
+    """Freeze a removed PV/battery adapter's levelized totals into the ledger.
+
+    The per-adapter accumulated sensors already display ``base × correction``,
+    so snapshotting their live state captures the final corrected contribution.
+    This keeps the combined levelized totals from dropping when an end-of-life
+    device is removed.
+    """
+    ent_reg = er.async_get(hass)
+    totals: dict[str, float] = {}
+    for key in LEVELIZED_TOTAL_KEYS:
+        unique_id = f"{entry.entry_id}_{subentry.subentry_id}_{key}"
+        entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, unique_id)
+        if entity_id is None:
+            continue
+        state = hass.states.get(entity_id)
+        if state is None or state.state in (STATE_UNAVAILABLE, "unknown"):
+            continue
+        try:
+            totals[key] = float(state.state)
+        except (ValueError, TypeError):
+            continue
+
+    if not totals:
+        return
+
+    ledger = list(entry.data.get(CONF_RETIRED_ADAPTERS, []))
+    ledger.append(
+        {
+            "subentry_id": subentry.subentry_id,
+            "adapter_type": subentry.data.get("adapter", {}).get("adapter_type"),
+            "title": subentry.title,
+            "retired_at": datetime.now(UTC).isoformat(),
+            "totals": totals,
+        }
+    )
+    hass.config_entries.async_update_entry(
+        entry, data={**entry.data, CONF_RETIRED_ADAPTERS: ledger}
+    )
+
+
 async def async_remove_subentry(
     hass: HomeAssistant,
     entry: MyConfigEntry,
     subentry: ConfigSubentry,
 ) -> None:
-    """Raise repair issues for batteries that referenced the removed adapter."""
+    """Snapshot retired levelized totals and raise battery repair issues."""
     removed_type = subentry.data.get("adapter", {}).get("adapter_type")
+
+    # Freeze a removed end-of-life PV/battery adapter's contribution.
+    if removed_type in ("pv_system", "battery"):
+        _snapshot_retired_adapter(hass, entry, subentry)
+
     if removed_type not in ("grid", "pv_system"):
         return
 

--- a/custom_components/power_insight/adapter_models.py
+++ b/custom_components/power_insight/adapter_models.py
@@ -9,6 +9,7 @@ from .const import (
     CONF_ELECTRICITY_PRICE_ENTITY, CONF_CO2_INTENSITY_ENTITY,
     CONF_INITIAL_LCOE, CONF_INITIAL_CO2_INTENSITY,
     CONF_INITIAL_LCOS,
+    CONF_CORRECTION_FACTOR,
     CONF_EXPORTS_POWER, CONF_EXPORT_COMPENSATION,
     CONF_CHARGE_FROM_GRID, CONF_CHARGE_FROM_ADAPTERS,
 )
@@ -74,10 +75,11 @@ class PvAdapterModel:
     name: str
     power_entity: str
     power_entity_inverted: bool
-    lcoe: float
-    lco2_intensity: float
+    lcoe: float | None
+    lco2_intensity: float | None
     exports_power: bool
     export_compensation: float
+    correction_factor: float = 1.0
 
     @classmethod
     def from_subentry(cls, subentry) -> PvAdapterModel:
@@ -87,11 +89,12 @@ class PvAdapterModel:
             unique_id=subentry.subentry_id,
             name=subentry.title,
             power_entity=config[CONF_POWER_ENTITY],
-            power_entity_inverted=config[CONF_POWER_ENTITY_INVERTED],
-            lcoe=config[CONF_INITIAL_LCOE],
-            lco2_intensity=config[CONF_INITIAL_CO2_INTENSITY],
-            exports_power=config[CONF_EXPORTS_POWER],
-            export_compensation=config[CONF_EXPORT_COMPENSATION],
+            power_entity_inverted=config.get(CONF_POWER_ENTITY_INVERTED, False),
+            lcoe=config.get(CONF_INITIAL_LCOE),
+            lco2_intensity=config.get(CONF_INITIAL_CO2_INTENSITY),
+            exports_power=config.get(CONF_EXPORTS_POWER, False),
+            export_compensation=config.get(CONF_EXPORT_COMPENSATION, 0.0),
+            correction_factor=config.get(CONF_CORRECTION_FACTOR) or 1.0,
         )
 
     def create_adapter(self) -> PvAdapter:
@@ -105,6 +108,7 @@ class PvAdapterModel:
             lco2_intensity=self.lco2_intensity,
             exports_power=self.exports_power,
             export_compensation=self.export_compensation,
+            correction_factor=self.correction_factor,
         )
 
 
@@ -117,12 +121,13 @@ class BatteryAdapterModel:
     name: str
     power_entity: str
     power_entity_inverted: bool
-    lcos: float
-    lco2_intensity: float
+    lcos: float | None
+    lco2_intensity: float | None
     exports_power: bool
     export_compensation: float
     charge_from_grid: bool = True
     charge_from_adapters: list[str] = field(default_factory=list)
+    correction_factor: float = 1.0
 
     @classmethod
     def from_subentry(cls, subentry) -> BatteryAdapterModel:
@@ -132,13 +137,14 @@ class BatteryAdapterModel:
             unique_id=subentry.subentry_id,
             name=subentry.title,
             power_entity=config[CONF_POWER_ENTITY],
-            power_entity_inverted=config[CONF_POWER_ENTITY_INVERTED],
-            lcos=config[CONF_INITIAL_LCOS],
-            lco2_intensity=config[CONF_INITIAL_CO2_INTENSITY],
-            exports_power=config[CONF_EXPORTS_POWER],
-            export_compensation=config[CONF_EXPORT_COMPENSATION],
+            power_entity_inverted=config.get(CONF_POWER_ENTITY_INVERTED, False),
+            lcos=config.get(CONF_INITIAL_LCOS),
+            lco2_intensity=config.get(CONF_INITIAL_CO2_INTENSITY),
+            exports_power=config.get(CONF_EXPORTS_POWER, False),
+            export_compensation=config.get(CONF_EXPORT_COMPENSATION, 0.0),
             charge_from_grid=config.get(CONF_CHARGE_FROM_GRID, True),
             charge_from_adapters=config.get(CONF_CHARGE_FROM_ADAPTERS, []),
+            correction_factor=config.get(CONF_CORRECTION_FACTOR) or 1.0,
         )
 
     def create_adapter(self) -> BatteryAdapter:
@@ -154,6 +160,7 @@ class BatteryAdapterModel:
             export_compensation=self.export_compensation,
             charge_from_grid=self.charge_from_grid,
             charge_from_adapters=self.charge_from_adapters,
+            correction_factor=self.correction_factor,
         )
 
 

--- a/custom_components/power_insight/config_flow.py
+++ b/custom_components/power_insight/config_flow.py
@@ -1341,9 +1341,10 @@ class AdapterSubentryFlow(ConfigSubentryFlow):
                                 translation_key="reconfigure_battery_adapters",
                                 translation_placeholders={"battery_name": sub.title},
                             )
-                    self.hass.async_create_task(
-                        self.hass.config_entries.async_reload(parent_entry.entry_id)
-                    )
+                    # No explicit reload here: adding the subentry fires the
+                    # config-entry update listener, which performs the reload.
+                    # Reloading here as well would double-reload (deprecated
+                    # since HA 2026.6).
 
                 return result
 
@@ -1415,7 +1416,11 @@ class AdapterSubentryFlow(ConfigSubentryFlow):
                 ir.async_delete_issue(
                     self.hass, DOMAIN, f"reconfigure_battery_{subentry.subentry_id}"
                 )
-                return self.async_update_reload_and_abort(
+                # Update without reloading here: the subentry change fires the
+                # config-entry update listener, which performs the single
+                # reload. Combining a reloading flow method with the update
+                # listener is deprecated since HA 2026.6.
+                return self.async_update_and_abort(
                     self._get_entry(), subentry, data=updated
                 )
 

--- a/custom_components/power_insight/config_flow.py
+++ b/custom_components/power_insight/config_flow.py
@@ -36,6 +36,7 @@ from .const import (
     CONF_CURRENT_LCOE,
     CONF_INITIAL_LCOS,
     CONF_CURRENT_LCOS,
+    CONF_CORRECTION_FACTOR,
     CONF_INITIAL_CO2_INTENSITY,
     CONF_CURRENT_CO2_INTENSITY,
     CONF_EXPORTS_POWER,
@@ -247,6 +248,34 @@ def calculate_co2_intensity(
     return (footprint / production) * 1000
 
 
+def calculate_correction_factor(
+    fields: dict[str, Any], existing_data: dict[str, Any] | None = None
+) -> float:
+    """Return current_lcoe / default_lcoe for a PV adapter.
+
+    The base (default) LCOE is immutable and read from the existing adapter
+    config; the current LCOE is derived from the edited lifetime values. The
+    factor is time-constant, so multiplying an accumulated base total by it is
+    exact and retroactive. Defaults to 1.0 when either value is unavailable.
+    """
+    base = (existing_data or {}).get(CONF_INITIAL_LCOE)
+    current = calculate_lcoe(fields)
+    if not base or current is None:
+        return 1.0
+    return current / base
+
+
+def calculate_correction_factor_lcos(
+    fields: dict[str, Any], existing_data: dict[str, Any] | None = None
+) -> float:
+    """Return current_lcos / default_lcos for a battery adapter."""
+    base = (existing_data or {}).get(CONF_INITIAL_LCOS)
+    current = calculate_lcos(fields)
+    if not base or current is None:
+        return 1.0
+    return current / base
+
+
 # ============================================================================
 # FIELD DEFINITION CLASSES
 # ============================================================================
@@ -363,12 +392,6 @@ INSTANTANEOUS_RATES_SELECTOR = selector.SelectSelector(
             selector.SelectOptionDict(
                 value=CONF_CALCULATE_LEVELIZED_COST_RATES, label="Levelized costs"
             ),
-            selector.SelectOptionDict(
-                value=CONF_CALCULATE_CO2_INTENSITY_RATES, label="CO2 intensity"
-            ),
-            selector.SelectOptionDict(
-                value=CONF_CALCULATE_LEVELIZED_CO2_INTENSITY_RATES, label="Levelized CO2 intensity"
-            ),
         ],
         mode=selector.SelectSelectorMode.LIST,
         multiple=True,
@@ -383,12 +406,6 @@ INSTANTANEOUS_SAVING_RATES_SELECTOR = selector.SelectSelector(
             ),
             selector.SelectOptionDict(
                 value=CONF_CALCULATE_LEVELIZED_COST_SAVING_RATES, label="Levelized cost savings rate"
-            ),
-            selector.SelectOptionDict(
-                value=CONF_CALCULATE_CO2_SAVING_RATES, label="CO2 savings rate"
-            ),
-            selector.SelectOptionDict(
-                value=CONF_CALCULATE_LEVELIZED_CO2_SAVING_RATES, label="Levelized CO2 savings rate"
             ),
         ],
         mode=selector.SelectSelectorMode.LIST,
@@ -406,22 +423,10 @@ ACCUMULATED_ENTITIES_SELECTOR = selector.SelectSelector(
                 value=CONF_ACCUMULATE_LEVELIZED_COST_RATES, label="Levelized cost rate"
             ),
             selector.SelectOptionDict(
-                value=CONF_ACCUMULATE_CO2_INTENSITY_RATES, label="CO2 intensity rate"
-            ),
-            selector.SelectOptionDict(
-                value=CONF_ACCUMULATE_LEVELIZED_CO2_INTENSITY_RATES, label="Levelized CO2 intensity rate"
-            ),
-            selector.SelectOptionDict(
                 value=CONF_ACCUMULATE_COST_SAVING_RATES, label="Cost savings rate"
             ),
             selector.SelectOptionDict(
                 value=CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES, label="Levelized cost savings rate"
-            ),
-            selector.SelectOptionDict(
-                value=CONF_ACCUMULATE_CO2_SAVING_RATES, label="CO2 savings rate"
-            ),
-            selector.SelectOptionDict(
-                value=CONF_ACCUMULATE_LEVELIZED_CO2_SAVING_RATES, label="Levelized CO2 savings rate"
             ),
         ],
         mode=selector.SelectSelectorMode.LIST,
@@ -439,25 +444,27 @@ ACCUMULATED_ENTITIES_SELECTOR = selector.SelectSelector(
 
 CONFIG_ENTRY_FIELDS: dict[str, EntryField] = {
     # --- Shown in both initial config and options flow ---
+    # Moved to options-only so the initial config step asks for the name only.
+    # Fresh installs default to cost-savings rates + accumulated totals.
     CONF_CALCULATE_INSTANTANEOUS_RATES: EntryField(
         selector=INSTANTANEOUS_RATES_SELECTOR,
         required=True,
         default=[],
-        in_config_flow=True,
+        in_config_flow=False,
         in_options_flow=True,
     ),
     CONF_CALCULATE_INSTANTANEOUS_SAVING_RATES: EntryField(
         selector=INSTANTANEOUS_SAVING_RATES_SELECTOR,
         required=True,
-        default=[],
-        in_config_flow=True,
+        default=[CONF_CALCULATE_COST_SAVING_RATES],
+        in_config_flow=False,
         in_options_flow=True,
     ),
     CONF_CALCULATE_ACCUMULATED_ENTITIES: EntryField(
         selector=ACCUMULATED_ENTITIES_SELECTOR,
         required=True,
-        default=[],
-        in_config_flow=True,
+        default=[CONF_ACCUMULATE_COST_SAVING_RATES],
+        in_config_flow=False,
         in_options_flow=True,
     ),
 
@@ -567,15 +574,23 @@ PV_SYSTEM_FIELDS: dict[str, AdapterField | CalculatedAdapterField] = {
         in_reconfigure_flow=False,
         store_in_adapter_config=True,
     ),
-    # Raw calculation inputs — optional by default, required when levelized is active
+    # Raw calculation inputs — optional by default, required when levelized is active.
+    # Editable on reconfigure: updating these recomputes current_lcoe and a
+    # correction factor that retroactively rescales displayed levelized values.
     CONF_LIFETIME_PRODUCTION: AdapterField(
         selector=ENERGY_SELECTOR,
         required=False,
         required_fn=_levelized_production_required,
         default=vol.UNDEFINED,
         in_config_flow=True,
-        in_reconfigure_flow=False,
+        in_reconfigure_flow=True,
         store_in_data=True,
+        description=(
+            "Updating the lifetime values applies a correction factor that "
+            "retroactively rescales this device's displayed levelized values. "
+            "Note: once a device is removed, its contribution to the combined "
+            "totals is frozen at its removal value."
+        ),
     ),
     CONF_LIFETIME_COST: AdapterField(
         selector=MONEY_SELECTOR,
@@ -583,7 +598,7 @@ PV_SYSTEM_FIELDS: dict[str, AdapterField | CalculatedAdapterField] = {
         required_fn=_levelized_cost_required,
         default=vol.UNDEFINED,
         in_config_flow=True,
-        in_reconfigure_flow=False,
+        in_reconfigure_flow=True,
         store_in_data=True,
     ),
     CONF_CO2_FOOTPRINT: AdapterField(
@@ -595,7 +610,9 @@ PV_SYSTEM_FIELDS: dict[str, AdapterField | CalculatedAdapterField] = {
         in_reconfigure_flow=False,
         store_in_data=True,
     ),
-    # Calculated fields — derived from the raw inputs above
+    # Calculated fields — derived from the raw inputs above.
+    # The initial (base) LCOE is immutable; current_lcoe and the correction
+    # factor are recomputed on reconfigure from the edited lifetime values.
     CONF_INITIAL_LCOE: CalculatedAdapterField(
         calculator=calculate_lcoe,
         depends_on=[CONF_LIFETIME_COST, CONF_LIFETIME_PRODUCTION],
@@ -607,7 +624,14 @@ PV_SYSTEM_FIELDS: dict[str, AdapterField | CalculatedAdapterField] = {
         calculator=calculate_lcoe,
         depends_on=[CONF_LIFETIME_COST, CONF_LIFETIME_PRODUCTION],
         in_config_flow=True,
-        in_reconfigure_flow=False,
+        in_reconfigure_flow=True,
+        store_in_adapter_config=True,
+    ),
+    CONF_CORRECTION_FACTOR: CalculatedAdapterField(
+        calculator=calculate_correction_factor,
+        depends_on=[CONF_LIFETIME_COST, CONF_LIFETIME_PRODUCTION],
+        in_config_flow=True,
+        in_reconfigure_flow=True,
         store_in_adapter_config=True,
     ),
     CONF_INITIAL_CO2_INTENSITY: CalculatedAdapterField(
@@ -637,7 +661,7 @@ BATTERY_FIELDS: dict[str, AdapterField | CalculatedAdapterField] = {
     ),
     CONF_POWER_ENTITY: AdapterField(
         selector=ENTITY_SELECTOR,
-        required=False,
+        required=True,
         in_config_flow=True,
         in_reconfigure_flow=True,
         store_in_adapter_config=True,
@@ -685,15 +709,23 @@ BATTERY_FIELDS: dict[str, AdapterField | CalculatedAdapterField] = {
         in_reconfigure_flow=True,
         store_in_adapter_config=True,
     ),
-    # Raw calculation inputs — optional by default, required when levelized is active
+    # Raw calculation inputs — optional by default, required when levelized is active.
+    # Editable on reconfigure: updating these recomputes current_lcos and a
+    # correction factor that retroactively rescales displayed levelized values.
     CONF_LIFETIME_PRODUCTION: AdapterField(
         selector=ENERGY_SELECTOR,
         required=False,
         required_fn=_levelized_production_required,
         default=vol.UNDEFINED,
         in_config_flow=True,
-        in_reconfigure_flow=False,
+        in_reconfigure_flow=True,
         store_in_data=True,
+        description=(
+            "Updating the lifetime values applies a correction factor that "
+            "retroactively rescales this device's displayed levelized values. "
+            "Note: once a device is removed, its contribution to the combined "
+            "totals is frozen at its removal value."
+        ),
     ),
     CONF_LIFETIME_COST: AdapterField(
         selector=MONEY_SELECTOR,
@@ -701,7 +733,7 @@ BATTERY_FIELDS: dict[str, AdapterField | CalculatedAdapterField] = {
         required_fn=_levelized_cost_required,
         default=vol.UNDEFINED,
         in_config_flow=True,
-        in_reconfigure_flow=False,
+        in_reconfigure_flow=True,
         store_in_data=True,
     ),
     CONF_CO2_FOOTPRINT: AdapterField(
@@ -713,7 +745,9 @@ BATTERY_FIELDS: dict[str, AdapterField | CalculatedAdapterField] = {
         in_reconfigure_flow=False,
         store_in_data=True,
     ),
-    # Calculated fields
+    # Calculated fields.
+    # The initial (base) LCOS is immutable; current_lcos and the correction
+    # factor are recomputed on reconfigure from the edited lifetime values.
     CONF_INITIAL_LCOS: CalculatedAdapterField(
         calculator=calculate_lcos,
         depends_on=[CONF_LIFETIME_COST, CONF_LIFETIME_PRODUCTION],
@@ -725,7 +759,14 @@ BATTERY_FIELDS: dict[str, AdapterField | CalculatedAdapterField] = {
         calculator=calculate_lcos,
         depends_on=[CONF_LIFETIME_COST, CONF_LIFETIME_PRODUCTION],
         in_config_flow=True,
-        in_reconfigure_flow=False,
+        in_reconfigure_flow=True,
+        store_in_adapter_config=True,
+    ),
+    CONF_CORRECTION_FACTOR: CalculatedAdapterField(
+        calculator=calculate_correction_factor_lcos,
+        depends_on=[CONF_LIFETIME_COST, CONF_LIFETIME_PRODUCTION],
+        in_config_flow=True,
+        in_reconfigure_flow=True,
         store_in_adapter_config=True,
     ),
     CONF_INITIAL_CO2_INTENSITY: CalculatedAdapterField(
@@ -795,6 +836,26 @@ def _is_field_required(
     return field_def.required
 
 
+def _field_in_flow(
+    field_def: AdapterField | CalculatedAdapterField | EntryField,
+    flow_type: str,
+) -> bool:
+    """Return whether a field is shown/processed in the given flow."""
+    if isinstance(field_def, EntryField):
+        if flow_type == "config":
+            return field_def.in_config_flow
+        if flow_type == "options":
+            return field_def.in_options_flow
+        return True
+    if isinstance(field_def, AdapterField):
+        if flow_type == "config":
+            return field_def.in_config_flow
+        if flow_type == "reconfigure":
+            return field_def.in_reconfigure_flow
+        return True
+    return False  # CalculatedAdapterField is never user-visible
+
+
 def build_schema(
     fields: dict[str, AdapterField | CalculatedAdapterField | EntryField],
     flow_type: str,
@@ -862,11 +923,13 @@ def validate_fields(
     fields: dict[str, AdapterField | CalculatedAdapterField | EntryField],
     user_input: dict[str, Any],
     options: dict | None = None,
+    flow_type: str = "config",
 ) -> dict[str, str]:
     """Validate user input against field definitions.
 
     Runs registered per-field validators and checks that dynamically required
-    fields are not missing.
+    fields are not missing.  Only fields visible in *flow_type* are checked for
+    required-ness, so config-only fields are not flagged during a reconfigure.
     """
     options = options or {}
     errors: dict[str, str] = {}
@@ -884,9 +947,11 @@ def validate_fields(
                 _LOGGER.error("Validation error for %s: %s", field_name, err)
                 errors[field_name] = field_def.error_key
 
-    # Dynamic required-ness check
+    # Dynamic required-ness check (only for fields shown in this flow)
     for field_name, field_def in fields.items():
         if isinstance(field_def, CalculatedAdapterField):
+            continue
+        if not _field_in_flow(field_def, flow_type):
             continue
         if _is_field_required(field_def, options):
             val = user_input.get(field_name)
@@ -1076,11 +1141,21 @@ class PowerInsightConfigFlow(ConfigFlow, domain=DOMAIN):
             if not title:
                 errors[CONF_NAME] = "invalid_name"
             else:
-                # Remaining keys are the config-visible option fields.
+                # The initial form only collects the name, so seed the entry
+                # options from the options-flow field defaults (cost-savings
+                # rates + accumulated totals) and let any config-visible input
+                # override them. This guarantees fresh installs register the
+                # default sensors before the user opens the options flow.
+                option_defaults: dict[str, Any] = {
+                    fn: fd.default
+                    for fn, fd in CONFIG_ENTRY_FIELDS.items()
+                    if fd.in_options_flow and fd.default is not vol.UNDEFINED
+                }
+                option_defaults.update(user_input)
                 return self.async_create_entry(
                     title=title,
                     data={},
-                    options=user_input,
+                    options=option_defaults,
                 )
 
         # Seed defaults from the config-visible subset of CONFIG_ENTRY_FIELDS
@@ -1198,7 +1273,7 @@ class AdapterSubentryFlow(ConfigSubentryFlow):
 
         if user_input is not None:
             validation_errors = validate_fields(
-                self.hass, self._adapter_fields, user_input, options
+                self.hass, self._adapter_fields, user_input, options, "config"
             )
             errors.update(validation_errors)
 
@@ -1289,23 +1364,30 @@ class AdapterSubentryFlow(ConfigSubentryFlow):
 
         if user_input is not None:
             validation_errors = validate_fields(
-                self.hass, self._adapter_fields, user_input, options
+                self.hass, self._adapter_fields, user_input, options, "reconfigure"
             )
             errors.update(validation_errors)
 
             if not errors:
+                # Evaluate calculated fields (current_lcoe/lcos, correction
+                # factor) from the edited lifetime values, reading the immutable
+                # base (default_lcoe/lcos) from the existing config.
+                complete = calculate_fields(
+                    self._adapter_fields,
+                    user_input,
+                    "reconfigure",
+                    options,
+                    existing_data=adapter.get("config", {}),
+                )
+                new_adapter_config, new_top_level = split_by_storage(
+                    self._adapter_fields, complete
+                )
+
                 adapter_config = adapter.get("config", {}).copy()
-                for field_name, value in user_input.items():
-                    fd = self._adapter_fields.get(field_name)
-                    if (
-                        fd
-                        and isinstance(fd, AdapterField)
-                        and fd.store_in_adapter_config
-                        and fd.in_reconfigure_flow
-                    ):
-                        adapter_config[field_name] = value
+                adapter_config.update(new_adapter_config)
 
                 updated = subentry.data.copy()
+                updated.update(new_top_level)
                 updated["adapter"] = {
                     "adapter_type": self._adapter_type,
                     "key": adapter.get("key"),
@@ -1327,6 +1409,11 @@ class AdapterSubentryFlow(ConfigSubentryFlow):
             for k, v in adapter.get("config", {}).items()
             if k in self._adapter_fields
         }
+        # store_in_data fields (e.g. lifetime values) live at the subentry top
+        # level, not in adapter.config — seed them so reconfigure pre-fills them.
+        for k, v in subentry.data.items():
+            if k != "adapter" and k in self._adapter_fields:
+                seed.setdefault(k, v)
 
         # For charge_from_adapters, strip stale subentry IDs before seeding so
         # the selector is pre-populated with only currently valid selections.

--- a/custom_components/power_insight/config_flow.py
+++ b/custom_components/power_insight/config_flow.py
@@ -311,6 +311,8 @@ class AdapterField:
 
     selector: selector.Selector | None = None
     selector_fn: Callable[..., selector.Selector] | None = None
+    # Builds a selector from the HA-configured currency code (money fields).
+    currency_selector_fn: Callable[[str], selector.Selector] | None = None
     required: bool = False
     # When provided, overrides `required` dynamically based on current entry options.
     required_fn: Callable[[dict], bool] | None = None
@@ -365,9 +367,14 @@ ENERGY_SELECTOR = selector.NumberSelector(
     selector.NumberSelectorConfig(min=1, max=10**8, unit_of_measurement="kWh", mode="box")
 )
 
-MONEY_SELECTOR = selector.NumberSelector(
-    selector.NumberSelectorConfig(min=1, max=10**8, unit_of_measurement="€", mode="box")
-)
+def make_money_selector(currency: str) -> selector.NumberSelector:
+    """Build a money input selector labelled with the configured currency."""
+    return selector.NumberSelector(
+        selector.NumberSelectorConfig(
+            min=1, max=10**8, unit_of_measurement=currency, mode="box"
+        )
+    )
+
 
 CO2_SELECTOR = selector.NumberSelector(
     selector.NumberSelectorConfig(min=1, max=10**8, unit_of_measurement="kg", mode="box")
@@ -377,11 +384,14 @@ PERCENT_SELECTOR = selector.NumberSelector(
     selector.NumberSelectorConfig(min=1, max=100, unit_of_measurement="%", mode="slider")
 )
 
-COMPENSATION_SELECTOR = selector.NumberSelector(
-    selector.NumberSelectorConfig(
-        min=0.0, max=100.0, step=0.01, unit_of_measurement="€/kWh", mode="box"
+def make_compensation_selector(currency: str) -> selector.NumberSelector:
+    """Build an export-compensation selector labelled with ``<currency>/kWh``."""
+    return selector.NumberSelector(
+        selector.NumberSelectorConfig(
+            min=0.0, max=100.0, step=0.01,
+            unit_of_measurement=f"{currency}/kWh", mode="box",
+        )
     )
-)
 
 INSTANTANEOUS_RATES_SELECTOR = selector.SelectSelector(
     selector.SelectSelectorConfig(
@@ -566,7 +576,7 @@ PV_SYSTEM_FIELDS: dict[str, AdapterField | CalculatedAdapterField] = {
         store_in_adapter_config=True,
     ),
     CONF_EXPORT_COMPENSATION: AdapterField(
-        selector=COMPENSATION_SELECTOR,
+        currency_selector_fn=make_compensation_selector,
         required=False,
         required_fn=_export_compensation_required,
         default=0.08,
@@ -593,7 +603,7 @@ PV_SYSTEM_FIELDS: dict[str, AdapterField | CalculatedAdapterField] = {
         ),
     ),
     CONF_LIFETIME_COST: AdapterField(
-        selector=MONEY_SELECTOR,
+        currency_selector_fn=make_money_selector,
         required=False,
         required_fn=_levelized_cost_required,
         default=vol.UNDEFINED,
@@ -693,7 +703,7 @@ BATTERY_FIELDS: dict[str, AdapterField | CalculatedAdapterField] = {
         store_in_adapter_config=True,
     ),
     CONF_EXPORT_COMPENSATION: AdapterField(
-        selector=COMPENSATION_SELECTOR,
+        currency_selector_fn=make_compensation_selector,
         required=False,
         required_fn=_export_compensation_required,
         default=0.0,
@@ -728,7 +738,7 @@ BATTERY_FIELDS: dict[str, AdapterField | CalculatedAdapterField] = {
         ),
     ),
     CONF_LIFETIME_COST: AdapterField(
-        selector=MONEY_SELECTOR,
+        currency_selector_fn=make_money_selector,
         required=False,
         required_fn=_levelized_cost_required,
         default=vol.UNDEFINED,
@@ -863,6 +873,7 @@ def build_schema(
     options: dict | None = None,
     entry: ConfigEntry | None = None,
     exclude_subentry_id: str | None = None,
+    currency: str = "EUR",
 ) -> vol.Schema:
     """Build a voluptuous schema from field definitions.
 
@@ -872,6 +883,7 @@ def build_schema(
     exclude_subentry_id:  passed through to selector_fn (e.g. to omit the
                           subentry currently being reconfigured from its own
                           selector options).
+    currency:             ISO currency code used to label money input fields.
     """
     options = options or {}
     schema_dict: dict = {}
@@ -905,8 +917,11 @@ def build_schema(
             else vol.Optional(field_name, default=default)
         )
 
-        # Resolve the selector: prefer selector_fn (dynamic) over selector (static).
-        if isinstance(field_def, AdapterField) and field_def.selector_fn is not None:
+        # Resolve the selector: prefer the currency factory, then selector_fn
+        # (dynamic), then the static selector.
+        if isinstance(field_def, AdapterField) and field_def.currency_selector_fn is not None:
+            resolved_selector = field_def.currency_selector_fn(currency)
+        elif isinstance(field_def, AdapterField) and field_def.selector_fn is not None:
             resolved_selector = field_def.selector_fn(
                 entry, exclude_subentry_id=exclude_subentry_id
             )
@@ -1334,6 +1349,7 @@ class AdapterSubentryFlow(ConfigSubentryFlow):
 
         schema = build_schema(
             self._adapter_fields, "config", user_input, options, entry=parent_entry,
+            currency=self.hass.config.currency or "EUR",
         )
 
         return self.async_show_form(
@@ -1435,6 +1451,7 @@ class AdapterSubentryFlow(ConfigSubentryFlow):
             options,
             entry=parent_entry,
             exclude_subentry_id=subentry.subentry_id,
+            currency=self.hass.config.currency or "EUR",
         )
 
         return self.async_show_form(

--- a/custom_components/power_insight/const.py
+++ b/custom_components/power_insight/const.py
@@ -44,6 +44,12 @@ CONF_CURRENT_CO2_INTENSITY = "current_co2_intensity"
 CONF_INITIAL_LCOS = "default_lcos"
 CONF_CURRENT_LCOS = "current_lcos"
 
+# Correction factor (current_lcoe / default_lcoe), stored in adapter.config
+CONF_CORRECTION_FACTOR = "correction_factor"
+
+# Ledger of retired (removed end-of-life) adapters, stored in ConfigEntry.data
+CONF_RETIRED_ADAPTERS = "retired_adapters"
+
 # PV/Battery user settings (stored in adapter.config)
 CONF_EXPORTS_POWER = "exports_power"
 CONF_EXPORT_COMPENSATION = "export_compensation"

--- a/custom_components/power_insight/power_insight.py
+++ b/custom_components/power_insight/power_insight.py
@@ -533,6 +533,68 @@ class PowerInsight:
 
         return result
 
+    # ----------------------------->
+    # CORRECTION-FACTOR VARIANTS --->
+    # ----------------------------->
+    #
+    # These mirror the base combined levelized rates but scale each adapter's
+    # contribution by its (time-constant) correction factor. The base variants
+    # above are left untouched so the accumulating sensors keep integrating the
+    # base rate; correction is applied only to displayed values.
+
+    @property
+    def combined_lcoe_rate_corrected(self) -> float | None:
+        """Combined levelized cost rate with per-adapter correction applied."""
+        result = 0.0
+        adapters = [self.grid_adapter] + self.prod_adapters
+        for adapter in adapters:
+            if (lcoe_rate := adapter.lcoe_rate) is None:
+                return None
+
+            result += lcoe_rate * adapter.correction_factor
+
+        return result
+
+    @property
+    def combined_lcoo_rate_corrected(self) -> float | None:
+        """Combined levelized operating cost rate with correction applied."""
+        result = 0.0
+        lcoo_rates = self.prod_adapters_lcoo_rates
+        for adapter in self.prod_adapters:
+            if (rate := lcoo_rates.get(adapter.uid)) is None:
+                return None
+
+            result += rate * adapter.correction_factor
+
+        return result
+
+    @property
+    def combined_levelized_saving_rate_corrected(self) -> float | None:
+        """Combined levelized cost savings rate with correction applied."""
+        result = 0.0
+        levelized_saving_rates = self.prod_adapters_levelized_cost_saving_rates
+        for adapter in self.prod_adapters:
+            if (rate := levelized_saving_rates.get(adapter.uid)) is None:
+                return None
+
+            result += rate * adapter.correction_factor
+
+        return result
+
+    @property
+    def levelized_correction_factors(self) -> dict[str, float]:
+        """Return ``uid -> correction_factor`` for prod adapters with an LCOE.
+
+        Used by the combined accumulated levelized sensor to enumerate the
+        active contributors whose per-adapter base totals it sums.
+        """
+        factors: dict[str, float] = {}
+        for adapter in self.prod_adapters:
+            if adapter.lcoe is not None:
+                factors[adapter.uid] = adapter.correction_factor
+
+        return factors
+
     # ------------------->
     # COMBINED PRICES --->
     # ------------------->
@@ -1148,7 +1210,7 @@ class PowerInsight:
                 earnings + avoided - lcoo_rate - lcoe_rate
             )
 
-        return
+        return saving_rates
 
     # -------------------->
     # STORAGE ADAPTERS --->
@@ -1640,7 +1702,7 @@ class PowerInsight:
                 earnings + avoided - lcoo_rate - lcoe_rate
             )
 
-        return
+        return saving_rates
 
     # ----------------------->
     # CONSUMPTION ADAPTERS --->
@@ -1812,6 +1874,16 @@ class AbstractBaseAdapter(ABC):
         self.uid = unique_id
         self.verbose_name = verbose_name
         self._values = {}
+
+    @property
+    def correction_factor(self) -> float:
+        """Return the levelized-cost correction factor (1.0 unless overridden).
+
+        Adapters with an editable lifetime cost (PV/battery) override this with
+        ``current_lcoe / default_lcoe``. The factor is time-constant, so it can
+        be applied to an accumulated base total to retroactively rescale it.
+        """
+        return 1.0
 
     # @property
     # def source_entities(self) -> list[str]:
@@ -2185,10 +2257,11 @@ class PvAdapter(BaseProductionAdapter):
         verbose_name: str,
         power_entity: str,
         power_entity_inverted: bool,
-        lcoe: float,
-        lco2_intensity: float,
+        lcoe: float | None,
+        lco2_intensity: float | None,
         exports_power: bool,
         export_compensation: float,
+        correction_factor: float = 1.0,
         **kwargs,
     ) -> None:
         """Initialize instance."""
@@ -2203,11 +2276,17 @@ class PvAdapter(BaseProductionAdapter):
         )
         self._lcoe = lcoe
         self._lco2_intensity = lco2_intensity
+        self._correction_factor = correction_factor
 
     @property
     def lcoe(self) -> float | None:
-        """Return the levelized cost of electicity in Euro/kwh."""
+        """Return the (base) levelized cost of electicity in Euro/kwh."""
         return self._lcoe
+
+    @property
+    def correction_factor(self) -> float:
+        """Return the levelized-cost correction factor for this PV system."""
+        return self._correction_factor
 
 class BatteryAdapter(BaseProductionAdapter):
     """Battery adapter."""
@@ -2220,12 +2299,13 @@ class BatteryAdapter(BaseProductionAdapter):
         verbose_name: str,
         power_entity: str,
         power_entity_inverted: bool,
-        lcos: float,
-        lco2_intensity: float,
+        lcos: float | None,
+        lco2_intensity: float | None,
         exports_power: bool,
         export_compensation: float,
         charge_from_grid: bool = True,
         charge_from_adapters: list[str] | None = None,
+        correction_factor: float = 1.0,
         **kwargs,
     ) -> None:
         """Initialize instance."""
@@ -2245,11 +2325,17 @@ class BatteryAdapter(BaseProductionAdapter):
         self.charge_from_adapters: list[str] = (
             charge_from_adapters if charge_from_adapters is not None else []
         )
+        self._correction_factor = correction_factor
 
     @property
     def lcoe(self) -> float | None:
-        """Return the levelized cost of electicity in Euro/kwh."""
+        """Return the (base) levelized cost of electicity in Euro/kwh."""
         return self._lcos
+
+    @property
+    def correction_factor(self) -> float:
+        """Return the levelized-cost correction factor for this battery."""
+        return self._correction_factor
 
 class BaseConsumerAdapter(BasePowerAdapter):
     """Base adapter for consumers."""

--- a/custom_components/power_insight/sensor.py
+++ b/custom_components/power_insight/sensor.py
@@ -1020,6 +1020,19 @@ class OptionsWrapper:
         return bool(self._options.get(key, False))
 
 
+def _resolve_currency_unit(unit: str | None, hass: HomeAssistant | None) -> str | None:
+    """Replace the ``EUR`` placeholder in a unit with the configured currency.
+
+    Falls back to the literal (``EUR``) when no currency is configured, so
+    existing setups keep their units unchanged.
+    """
+    if unit and "EUR" in unit and hass is not None:
+        currency = hass.config.currency
+        if currency:
+            return unit.replace("EUR", currency)
+    return unit
+
+
 def _retired_ledger_sum(config_entry: ConfigEntry, per_adapter_key: str) -> float:
     """Sum the frozen contributions of retired adapters for a levelized key.
 
@@ -1268,6 +1281,13 @@ class BasePowerInsightSensor(BaseEventSensorEntity):
         self.entity_description = description
         self.config_entry = config_entry
 
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Substitute the HA-configured currency for the EUR placeholder."""
+        return _resolve_currency_unit(
+            self.entity_description.native_unit_of_measurement, self.hass
+        )
+
 
 class PowerInsightSensor(BasePowerInsightSensor):
     """Hub-level sensor reading directly from PowerInsight."""
@@ -1443,6 +1463,13 @@ class BasePowerInsightIntegrationSensor(BaseEventIntegrationSensorEntity):
         super().__init__(source_entities, power_insight)
         self.entity_description = description
         self.config_entry = config_entry
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Substitute the HA-configured currency for the EUR placeholder."""
+        return _resolve_currency_unit(
+            self.entity_description.native_unit_of_measurement, self.hass
+        )
 
 
 class PowerInsightIntegrationSensor(BasePowerInsightIntegrationSensor):

--- a/custom_components/power_insight/sensor.py
+++ b/custom_components/power_insight/sensor.py
@@ -364,6 +364,10 @@ COMBINED_LEDGER_ADAPTER_KEYS: dict[str, str] = {
     "combined_total_levelized_cost_savings": "total_levelized_cost_savings",
 }
 
+# Per-adapter accumulated keys whose final corrected value is frozen into the
+# retired-adapter ledger when a device is removed.
+LEVELIZED_TOTAL_KEYS = frozenset(COMBINED_LEDGER_ADAPTER_KEYS.values())
+
 POWER_INSIGHT_COMBINED_LEDGER_SENSORS = (
     PowerInsightSensorDescription(
         key="combined_total_levelized_operating_costs",
@@ -1554,4 +1558,52 @@ class PowerInsightAdapterIntegrationSensor(BasePowerInsightIntegrationSensor):
             self._state,
             self.native_unit_of_measurement,
             self._last_valid_state,
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Freeze this levelized total into the ledger on device removal.
+
+        HA core never calls a component-level subentry-removal hook, and it
+        clears the removed subentry's entities synchronously before any reload
+        runs — so the only reliable place to capture a removed device's final
+        accumulated total is here, in its own teardown. We distinguish a genuine
+        device removal (the subentry is gone from the config entry) from an
+        ordinary reload (the subentry still exists), and only snapshot the former.
+        """
+        await super().async_will_remove_from_hass()
+
+        key = self.entity_description.key
+        if (
+            not self.entity_description.apply_correction_factor
+            or key not in LEVELIZED_TOTAL_KEYS
+        ):
+            return
+
+        uid = self.device_adapter.uid
+        # Subentry still present -> this is a reload/unload, not a removal.
+        if uid in self.config_entry.subentries:
+            return
+
+        value = self.native_value  # corrected (base * factor) total
+        if value is None:
+            return
+
+        ledger = list(self.config_entry.data.get(CONF_RETIRED_ADAPTERS, []))
+        # Idempotent: skip if this (device, key) was already captured.
+        if any(
+            entry.get("subentry_id") == uid and key in entry.get("totals", {})
+            for entry in ledger
+        ):
+            return
+
+        ledger.append(
+            {
+                "subentry_id": uid,
+                "title": self.device_adapter.verbose_name,
+                "totals": {key: float(value)},
+            }
+        )
+        self.hass.config_entries.async_update_entry(
+            self.config_entry,
+            data={**self.config_entry.data, CONF_RETIRED_ADAPTERS: ledger},
         )

--- a/custom_components/power_insight/sensor.py
+++ b/custom_components/power_insight/sensor.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
+from decimal import Decimal
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers import entity_registry as er
 from homeassistant.const import (
     PERCENTAGE,
     UnitOfPower,
@@ -20,7 +22,11 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 
-from .entity import BaseEventSensorEntity, BaseEventIntegrationSensorEntity
+from .entity import (
+    BaseEventSensorEntity,
+    BaseEventIntegrationSensorEntity,
+    IntegrationSensorExtraStoredData,
+)
 from .utils import get_value
 from .power_insight import PowerInsight, AbstractBaseAdapter
 from . import MyConfigEntry
@@ -35,6 +41,7 @@ from .const import (
     CONF_ACCUMULATE_LEVELIZED_COST_RATES,
     CONF_ACCUMULATE_COST_SAVING_RATES,
     CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES,
+    CONF_RETIRED_ADAPTERS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,6 +55,9 @@ class PowerInsightSensorDescription(SensorEntityDescription):
     exists_fn: Callable[..., bool] = lambda _: True
     value_fn: Callable[[PowerInsight], dict[str, float | None] | float | None]
     transform_fn: Callable[[float], float] = lambda value: value
+    # When True, a per-adapter sensor scales its displayed value by the
+    # adapter's correction factor (levelized quantities only).
+    apply_correction_factor: bool = False
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -58,6 +68,9 @@ class PowerInsightIntegrationSensorDescription(SensorEntityDescription):
     exists_fn: Callable[..., bool] = lambda _: True
     integration_value_fn: Callable[[PowerInsight], dict[str, float | None] | float | None]
     transform_fn: Callable[[float], float] = lambda value: value
+    # When True, the per-adapter integration sensor accumulates the base rate
+    # but displays the running total scaled by the adapter's correction factor.
+    apply_correction_factor: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -220,7 +233,7 @@ POWER_INSIGHT_SENSORS = (
         suggested_display_precision=2,
         entities_fn=lambda obj: obj.source_entities_power,
         exists_fn=lambda options: options.check(CONF_CALCULATE_LEVELIZED_COST_RATES),
-        value_fn=lambda obj: obj.combined_lcoe_rate,
+        value_fn=lambda obj: obj.combined_lcoe_rate_corrected,
     ),
     PowerInsightSensorDescription(
         key="combined_operating_cost_rate",
@@ -246,7 +259,7 @@ POWER_INSIGHT_SENSORS = (
             obj.source_entities_price + obj.source_entities_power
         ),
         exists_fn=lambda options: options.check(CONF_CALCULATE_LEVELIZED_COST_RATES),
-        value_fn=lambda obj: obj.combined_lcoo_rate,
+        value_fn=lambda obj: obj.combined_lcoo_rate_corrected,
     ),
     PowerInsightSensorDescription(
         key="combined_cost_savings_rate",
@@ -272,7 +285,7 @@ POWER_INSIGHT_SENSORS = (
             obj.source_entities_price + obj.source_entities_power
         ),
         exists_fn=lambda options: options.check(CONF_CALCULATE_LEVELIZED_COST_SAVING_RATES),
-        value_fn=lambda obj: obj.combined_levelized_saving_rate,
+        value_fn=lambda obj: obj.combined_levelized_saving_rate_corrected,
     ),
 )
 
@@ -304,19 +317,6 @@ POWER_INSIGHT_INTEGRATION_SENSORS = (
         integration_value_fn=lambda obj: obj.combined_coo_rate,
     ),
     PowerInsightIntegrationSensorDescription(
-        key="combined_total_levelized_operating_costs",
-        name="Combined total levelized operating costs",
-        native_unit_of_measurement="EUR",
-        state_class=SensorStateClass.TOTAL,
-        device_class=SensorDeviceClass.MONETARY,
-        suggested_display_precision=2,
-        entities_fn=lambda obj: (
-            obj.source_entities_price + obj.source_entities_power
-        ),
-        exists_fn=lambda options: options.check(CONF_ACCUMULATE_LEVELIZED_COST_RATES),
-        integration_value_fn=lambda obj: obj.combined_lcoo_rate,
-    ),
-    PowerInsightIntegrationSensorDescription(
         key="combined_total_self_consumption_cost_savings",
         name="Combined total self-consumption cost savings",
         native_unit_of_measurement="EUR",
@@ -342,7 +342,43 @@ POWER_INSIGHT_INTEGRATION_SENSORS = (
         exists_fn=lambda options: options.check(CONF_ACCUMULATE_COST_SAVING_RATES),
         integration_value_fn=lambda obj: obj.combined_saving_rate,
     ),
-    PowerInsightIntegrationSensorDescription(
+)
+
+
+# ---------------------------------------------------------------------------
+# Combined accumulated levelized sensors (derived + retired-adapter ledger)
+#
+# These do NOT integrate a pre-summed combined rate. Instead they derive their
+# value at read time as the sum of the per-adapter base accumulated totals
+# (each already scaled by that adapter's correction factor for display) plus a
+# persistent ledger of removed end-of-life adapters. This keeps the combined
+# total consistent with the per-adapter totals, makes lifetime-value
+# corrections retroactive, and prevents a removed device from dropping its
+# historical contribution.
+# ---------------------------------------------------------------------------
+
+# Maps each combined ledger sensor key to the per-adapter accumulated key it
+# sums over.
+COMBINED_LEDGER_ADAPTER_KEYS: dict[str, str] = {
+    "combined_total_levelized_operating_costs": "total_levelized_operating_costs",
+    "combined_total_levelized_cost_savings": "total_levelized_cost_savings",
+}
+
+POWER_INSIGHT_COMBINED_LEDGER_SENSORS = (
+    PowerInsightSensorDescription(
+        key="combined_total_levelized_operating_costs",
+        name="Combined total levelized operating costs",
+        native_unit_of_measurement="EUR",
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: (
+            obj.source_entities_price + obj.source_entities_power
+        ),
+        exists_fn=lambda options: options.check(CONF_ACCUMULATE_LEVELIZED_COST_RATES),
+        value_fn=lambda obj: None,
+    ),
+    PowerInsightSensorDescription(
         key="combined_total_levelized_cost_savings",
         name="Combined total levelized cost savings",
         native_unit_of_measurement="EUR",
@@ -353,7 +389,7 @@ POWER_INSIGHT_INTEGRATION_SENSORS = (
             obj.source_entities_price + obj.source_entities_power
         ),
         exists_fn=lambda options: options.check(CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES),
-        integration_value_fn=lambda obj: obj.combined_levelized_saving_rate,
+        value_fn=lambda obj: None,
     ),
 )
 
@@ -577,7 +613,9 @@ POWER_INSIGHT_PV_ADAPTER_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
+        exists_fn=lambda adapter: adapter.lcoe is not None,
         value_fn=lambda obj: obj.prod_adapters_lcoo_rates,
+        apply_correction_factor=True,
     ),
     PowerInsightSensorDescription(
         key="cost_savings_rate",
@@ -601,7 +639,9 @@ POWER_INSIGHT_PV_ADAPTER_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
+        exists_fn=lambda adapter: adapter.lcoe is not None,
         value_fn=lambda obj: obj.prod_adapters_levelized_cost_saving_rates,
+        apply_correction_factor=True,
     ),
 )
 
@@ -641,7 +681,9 @@ POWER_INSIGHT_PV_ADAPTER_INTEGRATION_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
+        exists_fn=lambda adapter: adapter.lcoe is not None,
         integration_value_fn=lambda obj: obj.prod_adapters_lcoo_rates,
+        apply_correction_factor=True,
     ),
     PowerInsightIntegrationSensorDescription(
         key="total_self_consumption_cost_savings",
@@ -677,7 +719,9 @@ POWER_INSIGHT_PV_ADAPTER_INTEGRATION_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
+        exists_fn=lambda adapter: adapter.lcoe is not None,
         integration_value_fn=lambda obj: obj.prod_adapters_levelized_cost_saving_rates,
+        apply_correction_factor=True,
     ),
 )
 
@@ -804,7 +848,9 @@ POWER_INSIGHT_STORAGE_ADAPTER_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
+        exists_fn=lambda adapter: adapter.lcoe is not None,
         value_fn=lambda obj: obj.storage_adapters_lcoo_rates,
+        apply_correction_factor=True,
     ),
     PowerInsightSensorDescription(
         key="cost_savings_rate",
@@ -828,7 +874,9 @@ POWER_INSIGHT_STORAGE_ADAPTER_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
+        exists_fn=lambda adapter: adapter.lcoe is not None,
         value_fn=lambda obj: obj.storage_adapters_levelized_cost_saving_rates,
+        apply_correction_factor=True,
     ),
 )
 
@@ -868,7 +916,9 @@ POWER_INSIGHT_STORAGE_ADAPTER_INTEGRATION_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
+        exists_fn=lambda adapter: adapter.lcoe is not None,
         integration_value_fn=lambda obj: obj.storage_adapters_lcoo_rates,
+        apply_correction_factor=True,
     ),
     PowerInsightIntegrationSensorDescription(
         key="total_self_consumption_cost_savings",
@@ -904,7 +954,9 @@ POWER_INSIGHT_STORAGE_ADAPTER_INTEGRATION_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
+        exists_fn=lambda adapter: adapter.lcoe is not None,
         integration_value_fn=lambda obj: obj.storage_adapters_levelized_cost_saving_rates,
+        apply_correction_factor=True,
     ),
 )
 
@@ -968,6 +1020,21 @@ class OptionsWrapper:
         return bool(self._options.get(key, False))
 
 
+def _retired_ledger_sum(config_entry: ConfigEntry, per_adapter_key: str) -> float:
+    """Sum the frozen contributions of retired adapters for a levelized key.
+
+    A retired (removed end-of-life) adapter's final corrected accumulated total
+    is persisted in ``config_entry.data[CONF_RETIRED_ADAPTERS]`` so that the
+    combined total never drops when the device is removed.
+    """
+    total = 0.0
+    for retired in config_entry.data.get(CONF_RETIRED_ADAPTERS, []):
+        value = retired.get("totals", {}).get(per_adapter_key)
+        if value is not None:
+            total += value
+    return total
+
+
 # ---------------------------------------------------------------------------
 # Platform setup
 # ---------------------------------------------------------------------------
@@ -1000,6 +1067,18 @@ async def async_setup_entry(
         if not description.exists_fn(options_wrapped):
             continue
         entities.append(PowerInsightIntegrationSensor(
+            description=description,
+            config_entry=entry,
+            source_entities=description.entities_fn(power_insight),
+            power_insight=power_insight,
+        ))
+
+    # Combined accumulated levelized sensors are derived (summed from the
+    # per-adapter base totals + retired-adapter ledger), not integrated.
+    for description in POWER_INSIGHT_COMBINED_LEDGER_SENSORS:
+        if not description.exists_fn(options_wrapped):
+            continue
+        entities.append(PowerInsightCombinedLedgerSensor(
             description=description,
             config_entry=entry,
             source_entities=description.entities_fn(power_insight),
@@ -1220,6 +1299,52 @@ class PowerInsightSensor(BasePowerInsightSensor):
         return value
 
 
+class PowerInsightCombinedLedgerSensor(PowerInsightSensor):
+    """Combined accumulated levelized sensor derived from per-adapter totals.
+
+    Recomputes on every source event as the sum of the active per-adapter base
+    accumulated totals (each already scaled by its adapter's correction factor
+    for display) plus the frozen contributions of removed end-of-life adapters.
+    It stores no running total itself, so there is no reload double-count, and
+    a lifetime-value correction is reflected retroactively and consistently in
+    both the per-adapter and the combined totals.
+    """
+
+    def __init__(
+            self,
+            description: PowerInsightSensorDescription,
+            config_entry: ConfigEntry,
+            source_entities: list[str],
+            power_insight: PowerInsight,
+    ) -> None:
+        """Initialize the combined ledger sensor."""
+        super().__init__(description, config_entry, source_entities, power_insight)
+        self._per_adapter_key = COMBINED_LEDGER_ADAPTER_KEYS[description.key]
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the summed per-adapter totals plus the retired ledger."""
+        ent_reg = er.async_get(self.hass)
+        total = 0.0
+        for uid in self.power_insight.levelized_correction_factors:
+            unique_id = (
+                f"{self.config_entry.entry_id}_{uid}_{self._per_adapter_key}"
+            )
+            entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, unique_id)
+            if entity_id is None:
+                continue
+            state = self.hass.states.get(entity_id)
+            if state is None or state.state in ("unknown", "unavailable"):
+                continue
+            try:
+                total += float(state.state)
+            except (ValueError, TypeError):
+                continue
+
+        total += _retired_ledger_sum(self.config_entry, self._per_adapter_key)
+        return total
+
+
 class PowerInsightAdapterSensor(BasePowerInsightSensor):
     """Per-adapter sensor that extracts its value from a uid-keyed dict."""
 
@@ -1250,6 +1375,8 @@ class PowerInsightAdapterSensor(BasePowerInsightSensor):
         value = get_value(self.device_adapter.uid, value)
         if value is not None:
             value = self.entity_description.transform_fn(value)
+            if self.entity_description.apply_correction_factor:
+                value = value * self.device_adapter.correction_factor
         return value
 
 
@@ -1373,9 +1500,31 @@ class PowerInsightAdapterIntegrationSensor(BasePowerInsightIntegrationSensor):
 
     @property
     def integration_value(self) -> float | None:
-        """Return the current rate value to integrate."""
+        """Return the current (base) rate value to integrate.
+
+        The correction factor is deliberately NOT applied here — the running
+        total accumulates the base rate so that the factor can be applied to
+        the displayed total retroactively.
+        """
         value = self.entity_description.integration_value_fn(self.power_insight)
         value = get_value(self.device_adapter.uid, value)
         if value is not None:
             value = self.entity_description.transform_fn(value)
         return value
+
+    @property
+    def native_value(self) -> Decimal | None:
+        """Return the accumulated base total, scaled for display if requested."""
+        base = self._state
+        if base is not None and self.entity_description.apply_correction_factor:
+            return base * Decimal(str(self.device_adapter.correction_factor))
+        return base
+
+    @property
+    def extra_restore_state_data(self) -> IntegrationSensorExtraStoredData:
+        """Persist the BASE running total (not the corrected display)."""
+        return IntegrationSensorExtraStoredData(
+            self._state,
+            self.native_unit_of_measurement,
+            self._last_valid_state,
+        )

--- a/custom_components/power_insight/translations/en.json
+++ b/custom_components/power_insight/translations/en.json
@@ -12,9 +12,9 @@
         },
         "data_description": {
           "name": "A name for this energy mix configuration.",
-          "calculate_instantaneous_rates": "Select which instantaneous rate sensors to create, e.g. cost rate (\u20ac/h) or CO\u2082 intensity rate.",
-          "calculate_instantaneous_saving_rates": "Select which instantaneous saving rate sensors to create, e.g. cost savings rate (\u20ac/h). Requires a price or CO\u2082 entity on the grid adapter depending on your selection.",
-          "calculate_accumulated_entities": "Select which accumulated total sensors to create, e.g. cost savings (\u20ac) or export compensation (\u20ac)."
+          "calculate_instantaneous_rates": "Select which instantaneous rate sensors to create, e.g. cost rate (per hour) or CO\u2082 intensity rate.",
+          "calculate_instantaneous_saving_rates": "Select which instantaneous saving rate sensors to create, e.g. cost savings rate (per hour). Requires a price or CO\u2082 entity on the grid adapter depending on your selection.",
+          "calculate_accumulated_entities": "Select which accumulated total sensors to create, e.g. cost savings or export compensation."
         }
       }
     },
@@ -39,9 +39,9 @@
           "debug_power_entities": "Enable debug power entities"
         },
         "data_description": {
-          "calculate_instantaneous_rates": "Select which instantaneous rate sensors to create, e.g. cost rate (\u20ac/h) or CO\u2082 intensity rate.",
-          "calculate_instantaneous_saving_rates": "Select which instantaneous saving rate sensors to create, e.g. cost savings rate (\u20ac/h). Requires a price or CO\u2082 entity on the grid adapter depending on your selection.",
-          "calculate_accumulated_entities": "Select which accumulated total sensors to create, e.g. cost savings (\u20ac) or export compensation (\u20ac).",
+          "calculate_instantaneous_rates": "Select which instantaneous rate sensors to create, e.g. cost rate (per hour) or CO\u2082 intensity rate.",
+          "calculate_instantaneous_saving_rates": "Select which instantaneous saving rate sensors to create, e.g. cost savings rate (per hour). Requires a price or CO\u2082 entity on the grid adapter depending on your selection.",
+          "calculate_accumulated_entities": "Select which accumulated total sensors to create, e.g. cost savings or export compensation.",
           "enable_power_shares": "Create sensors for percentage shares such as export share and self-consumption share.",
           "debug_power_entities": "Expose power values used by the internal calculations as additional sensors. Useful for troubleshooting."
         }
@@ -89,33 +89,37 @@
             "name": "A unique name for this device.",
             "power_entity": "Sensor reporting power in W, kW, or MW. For the grid: positive = import, negative = export.",
             "power_entity_inverted": "Enable if your sensor reports the power direction inverted.",
-            "grid_electricity_price_entity": "Sensor or input number providing the current electricity price in \u20ac/kWh. Required when cost calculations are enabled.",
+            "grid_electricity_price_entity": "Sensor or input number providing the current electricity price per kWh (in your Home Assistant currency). Required when cost calculations are enabled.",
             "co2_intensity_entity": "Sensor providing the current grid CO\u2082 intensity in g/kWh. Required when CO\u2082 calculations are enabled.",
             "exports_power": "Enable if this device can export excess power to the grid.",
-            "export_compensation": "Rate received per kWh exported to the grid (\u20ac/kWh). Required when cost savings calculation is enabled.",
+            "export_compensation": "Rate received per kWh exported to the grid (in your configured currency per kWh). Required when cost savings calculation is enabled.",
             "battery_efficiency": "The round-trip efficiency of the battery in percent.",
             "charge_from_adapters": "Select which adapters (grid and/or PV systems) this battery is allowed to charge from.",
             "lifetime_production": "Total expected energy production over the device lifetime (kWh). Required when levelized calculation is enabled.",
-            "lifetime_cost": "Total investment and installation cost over the device lifetime (\u20ac). Required when levelized cost calculation is enabled.",
+            "lifetime_cost": "Total investment and installation cost over the device lifetime (in your configured currency). Required when levelized cost calculation is enabled.",
             "co2_footprint": "Total CO\u2082 emissions from manufacturing and installation (kg). Required when levelized CO\u2082 calculation is enabled."
           }
         },
         "reconfigure": {
           "title": "Reconfigure {adapter_type}",
-          "description": "Update entity IDs for this adapter. To change lifetime cost or production values, remove and re-add the device.",
+          "description": "Update this adapter. Editing the lifetime cost or production values applies a correction factor that retroactively rescales this device's displayed levelized values.",
           "data": {
             "power_entity": "Power Entity",
             "power_entity_inverted": "Invert Power Direction",
             "grid_electricity_price_entity": "Electricity Price Entity",
             "co2_intensity_entity": "CO\u2082 Intensity Entity",
-            "charge_from_adapters": "Charge From"
+            "charge_from_adapters": "Charge From",
+            "lifetime_production": "Lifetime Production",
+            "lifetime_cost": "Total Lifetime Cost"
           },
           "data_description": {
             "power_entity": "Sensor reporting power in W, kW, or MW.",
             "power_entity_inverted": "Enable if your sensor reports the power direction inverted.",
-            "grid_electricity_price_entity": "Sensor or input number providing the current electricity price in \u20ac/kWh. Required when cost calculations are enabled.",
+            "grid_electricity_price_entity": "Sensor or input number providing the current electricity price per kWh (in your Home Assistant currency). Required when cost calculations are enabled.",
             "co2_intensity_entity": "Sensor providing the current grid CO\u2082 intensity in g/kWh. Required when CO\u2082 calculations are enabled.",
-            "charge_from_adapters": "Select which adapters (grid and/or PV systems) this battery is allowed to charge from."
+            "charge_from_adapters": "Select which adapters (grid and/or PV systems) this battery is allowed to charge from.",
+            "lifetime_production": "Total expected energy production over the device lifetime (kWh). Updating this rescales the displayed levelized values.",
+            "lifetime_cost": "Total investment and installation cost over the device lifetime (in your configured currency). Updating this rescales the displayed levelized values."
           }
         }
       },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -32,34 +32,31 @@ async def test_user_step_empty_name_returns_error(hass: HomeAssistant) -> None:
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={
-            "name": "",
-            "calculate_instantaneous_rates": [],
-            "calculate_instantaneous_saving_rates": [],
-            "calculate_accumulated_entities": [],
-        },
+        user_input={"name": ""},
     )
     assert result["type"] == FlowResultType.FORM
     assert "name" in result["errors"]
 
 
 async def test_user_step_creates_entry(hass: HomeAssistant) -> None:
-    """Submitting valid user data should create a config entry."""
+    """The initial step collects only the name and seeds the default options."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "user"}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={
-            "name": "Test PowerInsight",
-            "calculate_instantaneous_rates": [],
-            "calculate_instantaneous_saving_rates": [],
-            "calculate_accumulated_entities": [],
-        },
+        user_input={"name": "Test PowerInsight"},
     )
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "Test PowerInsight"
+    # Fresh installs default to cost-savings rates + accumulated totals.
     assert result["options"]["calculate_instantaneous_rates"] == []
+    assert result["options"]["calculate_instantaneous_saving_rates"] == [
+        "calculate_cost_saving_rates"
+    ]
+    assert result["options"]["calculate_accumulated_entities"] == [
+        "accumulate_cost_saving_rates"
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_simplification.py
+++ b/tests/test_config_simplification.py
@@ -1,0 +1,66 @@
+"""Tests for the config-flow simplification and field audit (items A & B)."""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.power_insight.config_flow import (
+    BATTERY_FIELDS,
+    CONFIG_ENTRY_FIELDS,
+    INSTANTANEOUS_RATES_SELECTOR,
+    INSTANTANEOUS_SAVING_RATES_SELECTOR,
+    ACCUMULATED_ENTITIES_SELECTOR,
+)
+from custom_components.power_insight.const import (
+    CONF_POWER_ENTITY,
+    CONF_CALCULATE_INSTANTANEOUS_RATES,
+    CONF_CALCULATE_INSTANTANEOUS_SAVING_RATES,
+    CONF_CALCULATE_ACCUMULATED_ENTITIES,
+    CONF_CALCULATE_COST_SAVING_RATES,
+    CONF_ACCUMULATE_COST_SAVING_RATES,
+)
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+def _option_values(select_selector) -> set[str]:
+    return {opt["value"] for opt in select_selector.config["options"]}
+
+
+# --- A1: the three multiselects are options-only with new defaults ---
+
+def test_multiselects_are_options_only() -> None:
+    for key in (
+        CONF_CALCULATE_INSTANTANEOUS_RATES,
+        CONF_CALCULATE_INSTANTANEOUS_SAVING_RATES,
+        CONF_CALCULATE_ACCUMULATED_ENTITIES,
+    ):
+        field = CONFIG_ENTRY_FIELDS[key]
+        assert field.in_config_flow is False
+        assert field.in_options_flow is True
+
+
+def test_fresh_install_defaults() -> None:
+    assert CONFIG_ENTRY_FIELDS[CONF_CALCULATE_INSTANTANEOUS_RATES].default == []
+    assert CONFIG_ENTRY_FIELDS[
+        CONF_CALCULATE_INSTANTANEOUS_SAVING_RATES
+    ].default == [CONF_CALCULATE_COST_SAVING_RATES]
+    assert CONFIG_ENTRY_FIELDS[
+        CONF_CALCULATE_ACCUMULATED_ENTITIES
+    ].default == [CONF_ACCUMULATE_COST_SAVING_RATES]
+
+
+# --- A2: CO2 options stripped from the three selectors ---
+
+def test_selectors_have_no_co2_options() -> None:
+    for selector in (
+        INSTANTANEOUS_RATES_SELECTOR,
+        INSTANTANEOUS_SAVING_RATES_SELECTOR,
+        ACCUMULATED_ENTITIES_SELECTOR,
+    ):
+        assert not any("co2" in value for value in _option_values(selector))
+
+
+# --- B1: battery power entity is required ---
+
+def test_battery_power_entity_required() -> None:
+    assert BATTERY_FIELDS[CONF_POWER_ENTITY].required is True

--- a/tests/test_correction_factor.py
+++ b/tests/test_correction_factor.py
@@ -1,0 +1,145 @@
+"""Engine tests for the levelized-cost correction factor and the B4 bug fix.
+
+These import ``power_insight.py`` directly via importlib (HA-free), mirroring
+``test_power_insight_calculations.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+
+import pytest
+
+_MODULE_PATH = os.path.join(
+    os.path.dirname(__file__),
+    os.pardir,
+    "custom_components",
+    "power_insight",
+    "power_insight.py",
+)
+_spec = importlib.util.spec_from_file_location("power_insight", _MODULE_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+PowerInsight = _mod.PowerInsight
+GridAdapter = _mod.GridAdapter
+PvAdapter = _mod.PvAdapter
+BatteryAdapter = _mod.BatteryAdapter
+ConsumerAdapter = _mod.ConsumerAdapter
+
+
+GRID_POWER = "sensor.grid_power"
+GRID_PRICE = "sensor.grid_price"
+PV1_POWER = "sensor.pv1_power"
+CONS_POWER = "sensor.cons_power"
+
+
+def _build(pv_correction_factor: float = 1.0):
+    """Grid (import) + one producing PV + one consumer."""
+    pi = PowerInsight()
+    pi.register_adapter(
+        GridAdapter(
+            unique_id="grid",
+            verbose_name="Grid",
+            power_entity=GRID_POWER,
+            price_entity=GRID_PRICE,
+        )
+    )
+    pi.register_adapter(
+        PvAdapter(
+            unique_id="pv1",
+            verbose_name="PV-1",
+            power_entity=PV1_POWER,
+            power_entity_inverted=False,
+            lcoe=0.10,
+            lco2_intensity=35.0,
+            exports_power=True,
+            export_compensation=0.08,
+            correction_factor=pv_correction_factor,
+        )
+    )
+    pi.register_adapter(
+        ConsumerAdapter(
+            unique_id="cons",
+            verbose_name="Consumer",
+            power_entity=CONS_POWER,
+        )
+    )
+    pi.set_value(GRID_POWER, 1000.0)
+    pi.set_value(GRID_PRICE, 0.30)
+    pi.set_value(PV1_POWER, 2000.0)
+    pi.set_value(CONS_POWER, 800.0)
+    return pi
+
+
+# ---------------------------------------------------------------------------
+# C1 — correction factor
+# ---------------------------------------------------------------------------
+
+def test_pv_adapter_lcoe_is_base_value() -> None:
+    """The adapter's lcoe stays the immutable base; the factor is separate."""
+    pi = _build(pv_correction_factor=1.5)
+    pv = pi.get_adapter_by_uid("pv1")
+    assert pv.lcoe == 0.10
+    assert pv.correction_factor == 1.5
+    # lcoe_rate uses the base value: (2000 / 1000) * 0.10 = 0.20
+    assert pv.lcoe_rate == pytest.approx(0.20)
+
+
+def test_grid_correction_factor_defaults_to_one() -> None:
+    """Adapters without an editable lifetime cost have a unit factor."""
+    pi = _build()
+    assert pi.get_adapter_by_uid("grid").correction_factor == 1.0
+
+
+def test_combined_lcoe_rate_corrected_scales_each_term() -> None:
+    """Corrected combined rate = sum of factor_i * base_rate_i."""
+    pi = _build(pv_correction_factor=1.5)
+    # grid: (1000/1000)*0.30 = 0.30 (factor 1.0); pv: 0.20 * 1.5 = 0.30
+    assert pi.combined_lcoe_rate == pytest.approx(0.30 + 0.20)
+    assert pi.combined_lcoe_rate_corrected == pytest.approx(0.30 + 0.30)
+
+
+def test_combined_corrected_equals_base_when_factor_is_one() -> None:
+    """With a unit factor the corrected variant matches the base."""
+    pi = _build(pv_correction_factor=1.0)
+    assert pi.combined_lcoe_rate_corrected == pytest.approx(pi.combined_lcoe_rate)
+    assert (
+        pi.combined_levelized_saving_rate_corrected
+        == pytest.approx(pi.combined_levelized_saving_rate)
+    )
+
+
+def test_levelized_correction_factors_mapping() -> None:
+    """Only prod adapters with an LCOE appear, keyed by uid."""
+    pi = _build(pv_correction_factor=1.5)
+    assert pi.levelized_correction_factors == {"pv1": 1.5}
+
+
+# ---------------------------------------------------------------------------
+# B4 — levelized cost saving rates no longer return None
+# ---------------------------------------------------------------------------
+
+def test_prod_levelized_cost_saving_rates_not_none() -> None:
+    """Regression: the property used to `return` bare None."""
+    pi = _build()
+    rates = pi.prod_adapters_levelized_cost_saving_rates
+    assert isinstance(rates, dict)
+    assert "pv1" in rates
+    assert rates["pv1"] is not None
+
+
+def test_combined_levelized_saving_rate_is_sum_of_dict() -> None:
+    """Combined equals the sum of the per-adapter dict values."""
+    pi = _build()
+    rates = pi.prod_adapters_levelized_cost_saving_rates
+    assert pi.combined_levelized_saving_rate == pytest.approx(sum(rates.values()))
+
+
+def test_combined_levelized_saving_rate_corrected_scales() -> None:
+    """Corrected combined savings = sum of factor_i * per-adapter savings."""
+    pi = _build(pv_correction_factor=2.0)
+    rates = pi.prod_adapters_levelized_cost_saving_rates
+    expected = sum(v * 2.0 for v in rates.values())
+    assert pi.combined_levelized_saving_rate_corrected == pytest.approx(expected)

--- a/tests/test_correction_flow.py
+++ b/tests/test_correction_flow.py
@@ -165,40 +165,12 @@ async def test_levelized_measurement_scaled_by_factor(hass: HomeAssistant) -> No
 
 
 # ---------------------------------------------------------------------------
-# C5b — removal ledger + combined derived sensor
+# C5b — combined derived sensor reads the retired-adapter ledger
+#
+# The full removal lifecycle (accumulate -> remove -> snapshot -> reload) is
+# covered end-to-end in tests/test_end_to_end.py; here we only check the read
+# side: a pre-seeded ledger is reflected in the combined derived sensor.
 # ---------------------------------------------------------------------------
-
-async def test_removal_snapshots_levelized_total_into_ledger(
-    hass: HomeAssistant,
-) -> None:
-    """Removing a PV adapter freezes its levelized total into the ledger."""
-    from custom_components.power_insight import async_remove_subentry
-    from custom_components.power_insight.const import CONF_RETIRED_ADAPTERS
-
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="My PowerInsight",
-        options=BASE_OPTIONS,
-        subentries_data=[make_grid_subentry_data(), make_pv_subentry_data()],
-    )
-    hass.states.async_set("sensor.grid_power", "0", {"unit_of_measurement": "W"})
-    hass.states.async_set("sensor.pv_power", "0", {"unit_of_measurement": "W"})
-    await setup_integration(hass, entry)
-
-    # Give the per-adapter accumulated levelized sensor a concrete value.
-    ent_reg = er.async_get(hass)
-    uid = f"{entry.entry_id}_{PV_SUB_ID}_total_levelized_operating_costs"
-    entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, uid)
-    assert entity_id is not None
-    hass.states.async_set(entity_id, "12.5")
-
-    await async_remove_subentry(hass, entry, entry.subentries[PV_SUB_ID])
-
-    ledger = entry.data.get(CONF_RETIRED_ADAPTERS, [])
-    assert len(ledger) == 1
-    assert ledger[0]["subentry_id"] == PV_SUB_ID
-    assert ledger[0]["totals"]["total_levelized_operating_costs"] == 12.5
-
 
 async def test_combined_ledger_sensor_includes_retired_totals(
     hass: HomeAssistant,

--- a/tests/test_correction_flow.py
+++ b/tests/test_correction_flow.py
@@ -1,0 +1,243 @@
+"""Tests for the correction-factor reconfigure flow and sensor display (item C)."""
+from __future__ import annotations
+
+import copy
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from .conftest import (
+    DOMAIN,
+    BASE_OPTIONS,
+    PV_SUB_ID,
+    GRID_SUB_ID,
+    make_grid_subentry_data,
+    make_pv_subentry_data,
+    setup_integration,
+)
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+def _pv_state(hass: HomeAssistant, entry: MockConfigEntry, suffix: str):
+    ent_reg = er.async_get(hass)
+    for ent in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
+        if ent.unique_id and ent.unique_id.endswith(suffix):
+            return hass.states.get(ent.entity_id)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# C2 — reconfigure recomputes the correction factor
+# ---------------------------------------------------------------------------
+
+async def test_reconfigure_pv_computes_correction_factor(
+    hass: HomeAssistant,
+) -> None:
+    """Editing lifetime cost yields current_lcoe and a correction factor.
+
+    The immutable base (default_lcoe) is left unchanged and the lifetime
+    values are written back to the subentry top level.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My PowerInsight",
+        options=BASE_OPTIONS,
+        subentries_data=[make_grid_subentry_data(), make_pv_subentry_data()],
+    )
+    entry.add_to_hass(hass)
+    hass.states.async_set("sensor.pv_power", "0", {"unit_of_measurement": "W"})
+
+    result = await hass.config_entries.subentries.async_init(
+        (entry.entry_id, "adapter"),
+        context={"source": "reconfigure", "subentry_id": PV_SUB_ID},
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    # Double the lifetime cost (production unchanged): lcoe 0.10 -> 0.20.
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        user_input={
+            "power_entity": "sensor.pv_power",
+            "power_entity_inverted": False,
+            "lifetime_production": 10000.0,
+            "lifetime_cost": 2000.0,
+        },
+    )
+    assert result["type"] == FlowResultType.ABORT  # update_reload_and_abort
+
+    subentry = entry.subentries[PV_SUB_ID]
+    config = subentry.data["adapter"]["config"]
+    assert config["default_lcoe"] == 0.10  # base unchanged
+    assert config["current_lcoe"] == pytest.approx(0.20)
+    assert config["correction_factor"] == pytest.approx(2.0)
+    # Lifetime values are persisted at the subentry top level.
+    assert subentry.data["lifetime_cost"] == 2000.0
+
+
+# ---------------------------------------------------------------------------
+# A3 — per-adapter levelized sensors gated on adapter.lcoe
+# ---------------------------------------------------------------------------
+
+async def test_levelized_sensors_absent_without_lcoe(hass: HomeAssistant) -> None:
+    """A PV adapter without a configured LCOE gets no levelized sensors."""
+    pv_data = copy.deepcopy(make_pv_subentry_data())
+    # Remove the levelized cost so adapter.lcoe is None.
+    pv_data["data"]["adapter"]["config"].pop("default_lcoe")
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My PowerInsight",
+        options=BASE_OPTIONS,
+        subentries_data=[make_grid_subentry_data(), pv_data],
+    )
+    hass.states.async_set("sensor.grid_power", "0", {"unit_of_measurement": "W"})
+    hass.states.async_set("sensor.pv_power", "0", {"unit_of_measurement": "W"})
+    await setup_integration(hass, entry)
+
+    ent_reg = er.async_get(hass)
+    uids = {
+        e.unique_id
+        for e in er.async_entries_for_config_entry(ent_reg, entry.entry_id)
+    }
+    assert f"{entry.entry_id}_{PV_SUB_ID}_levelized_operating_cost_rate" not in uids
+
+
+async def test_levelized_sensors_present_with_lcoe(hass: HomeAssistant) -> None:
+    """A PV adapter with a configured LCOE gets levelized sensors."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My PowerInsight",
+        options=BASE_OPTIONS,
+        subentries_data=[make_grid_subentry_data(), make_pv_subentry_data()],
+    )
+    hass.states.async_set("sensor.grid_power", "0", {"unit_of_measurement": "W"})
+    hass.states.async_set("sensor.pv_power", "0", {"unit_of_measurement": "W"})
+    await setup_integration(hass, entry)
+
+    ent_reg = er.async_get(hass)
+    uids = {
+        e.unique_id
+        for e in er.async_entries_for_config_entry(ent_reg, entry.entry_id)
+    }
+    assert f"{entry.entry_id}_{PV_SUB_ID}_levelized_operating_cost_rate" in uids
+
+
+# ---------------------------------------------------------------------------
+# C4 — per-adapter levelized display is scaled by the correction factor
+# ---------------------------------------------------------------------------
+
+async def test_levelized_measurement_scaled_by_factor(hass: HomeAssistant) -> None:
+    """The displayed levelized savings rate equals the base value × factor."""
+    grid_data = copy.deepcopy(make_grid_subentry_data())
+    grid_data["data"]["adapter"]["config"][
+        "grid_electricity_price_entity"
+    ] = "sensor.grid_price"
+    pv_data = copy.deepcopy(make_pv_subentry_data())
+    pv_data["data"]["adapter"]["config"]["correction_factor"] = 2.0
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My PowerInsight",
+        options=BASE_OPTIONS,
+        subentries_data=[grid_data, pv_data],
+    )
+    hass.states.async_set(
+        "sensor.grid_power", "1000", {"unit_of_measurement": "W"}
+    )
+    hass.states.async_set(
+        "sensor.grid_price", "0.30", {"unit_of_measurement": "EUR/kWh"}
+    )
+    hass.states.async_set(
+        "sensor.pv_power", "2000", {"unit_of_measurement": "W"}
+    )
+    await setup_integration(hass, entry)
+    await hass.async_block_till_done()
+
+    pi = entry.runtime_data.power_insight
+    base = pi.prod_adapters_levelized_cost_saving_rates.get(PV_SUB_ID)
+    state = _pv_state(hass, entry, f"{PV_SUB_ID}_levelized_cost_savings_rate")
+    assert state is not None
+    assert base is not None
+    assert float(state.state) == pytest.approx(base * 2.0, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# C5b — removal ledger + combined derived sensor
+# ---------------------------------------------------------------------------
+
+async def test_removal_snapshots_levelized_total_into_ledger(
+    hass: HomeAssistant,
+) -> None:
+    """Removing a PV adapter freezes its levelized total into the ledger."""
+    from custom_components.power_insight import async_remove_subentry
+    from custom_components.power_insight.const import CONF_RETIRED_ADAPTERS
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My PowerInsight",
+        options=BASE_OPTIONS,
+        subentries_data=[make_grid_subentry_data(), make_pv_subentry_data()],
+    )
+    hass.states.async_set("sensor.grid_power", "0", {"unit_of_measurement": "W"})
+    hass.states.async_set("sensor.pv_power", "0", {"unit_of_measurement": "W"})
+    await setup_integration(hass, entry)
+
+    # Give the per-adapter accumulated levelized sensor a concrete value.
+    ent_reg = er.async_get(hass)
+    uid = f"{entry.entry_id}_{PV_SUB_ID}_total_levelized_operating_costs"
+    entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, uid)
+    assert entity_id is not None
+    hass.states.async_set(entity_id, "12.5")
+
+    await async_remove_subentry(hass, entry, entry.subentries[PV_SUB_ID])
+
+    ledger = entry.data.get(CONF_RETIRED_ADAPTERS, [])
+    assert len(ledger) == 1
+    assert ledger[0]["subentry_id"] == PV_SUB_ID
+    assert ledger[0]["totals"]["total_levelized_operating_costs"] == 12.5
+
+
+async def test_combined_ledger_sensor_includes_retired_totals(
+    hass: HomeAssistant,
+) -> None:
+    """The combined derived sensor adds the frozen retired-adapter totals."""
+    from custom_components.power_insight.const import (
+        CONF_CALCULATE_ACCUMULATED_ENTITIES,
+        CONF_ACCUMULATE_LEVELIZED_COST_RATES,
+        CONF_RETIRED_ADAPTERS,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My PowerInsight",
+        options={
+            CONF_CALCULATE_ACCUMULATED_ENTITIES: [
+                CONF_ACCUMULATE_LEVELIZED_COST_RATES
+            ],
+        },
+        data={
+            CONF_RETIRED_ADAPTERS: [
+                {
+                    "subentry_id": "01OLDPV0000000000000000001",
+                    "adapter_type": "pv_system",
+                    "title": "Old PV",
+                    "retired_at": "2026-01-01T00:00:00+00:00",
+                    "totals": {"total_levelized_operating_costs": 42.0},
+                }
+            ],
+        },
+        subentries_data=[make_grid_subentry_data()],
+    )
+    hass.states.async_set("sensor.grid_power", "0", {"unit_of_measurement": "W"})
+    await setup_integration(hass, entry)
+
+    ent_reg = er.async_get(hass)
+    uid = f"{entry.entry_id}_combined_total_levelized_operating_costs"
+    entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, uid)
+    assert entity_id is not None
+    state = hass.states.get(entity_id)
+    # No active levelized adapters; the value is just the frozen ledger sum.
+    assert float(state.state) == pytest.approx(42.0)

--- a/tests/test_currency.py
+++ b/tests/test_currency.py
@@ -1,0 +1,116 @@
+"""Tests for currency handling — sensor units and config-flow input units."""
+from __future__ import annotations
+
+import types
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.power_insight.config_flow import (
+    build_schema,
+    PV_SYSTEM_FIELDS,
+)
+from custom_components.power_insight.sensor import _resolve_currency_unit
+from .conftest import (
+    DOMAIN,
+    BASE_OPTIONS,
+    PV_SUB_ID,
+    make_grid_subentry_data,
+    make_pv_subentry_data,
+    setup_integration,
+)
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+def _unit(hass: HomeAssistant, entry: MockConfigEntry, suffix: str) -> str | None:
+    ent_reg = er.async_get(hass)
+    for ent in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
+        if ent.unique_id and ent.unique_id.endswith(suffix):
+            state = hass.states.get(ent.entity_id)
+            return state.attributes.get("unit_of_measurement") if state else None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_currency_unit (pure helper)
+# ---------------------------------------------------------------------------
+
+def test_resolve_currency_unit_substitutes() -> None:
+    hass = types.SimpleNamespace(config=types.SimpleNamespace(currency="GBP"))
+    assert _resolve_currency_unit("EUR/h", hass) == "GBP/h"
+    assert _resolve_currency_unit("EUR/kWh", hass) == "GBP/kWh"
+    assert _resolve_currency_unit("EUR", hass) == "GBP"
+    # Non-currency units are untouched.
+    assert _resolve_currency_unit("W", hass) == "W"
+
+
+def test_resolve_currency_unit_falls_back_to_eur() -> None:
+    # No hass / no configured currency keeps the literal placeholder.
+    assert _resolve_currency_unit("EUR/h", None) == "EUR/h"
+    hass = types.SimpleNamespace(config=types.SimpleNamespace(currency=None))
+    assert _resolve_currency_unit("EUR/h", hass) == "EUR/h"
+
+
+# ---------------------------------------------------------------------------
+# Sensor units follow hass.config.currency
+# ---------------------------------------------------------------------------
+
+async def test_sensor_units_follow_currency(hass: HomeAssistant) -> None:
+    """Rate, total and price sensors report the configured currency."""
+    await hass.config.async_update(currency="USD")
+
+    grid = make_grid_subentry_data()
+    grid["data"]["adapter"]["config"][
+        "grid_electricity_price_entity"
+    ] = "sensor.grid_price"
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My PowerInsight",
+        options=BASE_OPTIONS,
+        subentries_data=[grid, make_pv_subentry_data()],
+    )
+    hass.states.async_set("sensor.grid_power", "1000", {"unit_of_measurement": "W"})
+    hass.states.async_set(
+        "sensor.grid_price", "0.30", {"unit_of_measurement": "USD/kWh"}
+    )
+    hass.states.async_set("sensor.pv_power", "-50", {"unit_of_measurement": "W"})
+    await setup_integration(hass, entry)
+    await hass.async_block_till_done()
+
+    # Rate sensor (EUR/h -> USD/h)
+    assert _unit(hass, entry, f"{PV_SUB_ID}_operating_cost_rate") == "USD/h"
+    # Accumulated total (EUR -> USD)
+    assert _unit(hass, entry, f"{PV_SUB_ID}_total_operating_costs") == "USD"
+    # Price sensor (EUR/kWh -> USD/kWh)
+    assert (
+        _unit(hass, entry, "combined_levelized_price_of_electricity") == "USD/kWh"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config-flow money selectors follow the currency
+# ---------------------------------------------------------------------------
+
+def _selector_for(schema, field_name):
+    for marker, sel in schema.schema.items():
+        if getattr(marker, "schema", marker) == field_name:
+            return sel
+    return None
+
+
+def test_money_selectors_use_currency() -> None:
+    schema = build_schema(PV_SYSTEM_FIELDS, "config", currency="USD")
+    cost = _selector_for(schema, "lifetime_cost")
+    comp = _selector_for(schema, "export_compensation")
+    assert cost.config["unit_of_measurement"] == "USD"
+    assert comp.config["unit_of_measurement"] == "USD/kWh"
+
+
+def test_money_selectors_default_currency() -> None:
+    schema = build_schema(PV_SYSTEM_FIELDS, "config")
+    assert _selector_for(schema, "lifetime_cost").config[
+        "unit_of_measurement"
+    ] == "EUR"

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,229 @@
+"""End-to-end integration tests: config entry -> loaded integration -> sensor states.
+
+These build a real ``ConfigEntry`` with subentries, load the integration via
+pytest-homeassistant-custom-component, feed source-entity states, and assert the
+actual rendered HA sensor states — instantaneous, accumulated (time-driven), and
+the removal-ledger lifecycle.
+"""
+from __future__ import annotations
+
+import copy
+from datetime import timedelta
+
+import pytest
+from freezegun import freeze_time
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+import homeassistant.util.dt as dt_util
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from .conftest import (
+    DOMAIN,
+    GRID_SUB_ID,
+    PV_SUB_ID,
+    make_grid_subentry_data,
+    make_pv_subentry_data,
+    setup_integration,
+)
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _state_obj(hass: HomeAssistant, entry: MockConfigEntry, suffix: str):
+    ent_reg = er.async_get(hass)
+    for ent in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
+        if ent.unique_id and ent.unique_id.endswith(suffix):
+            return hass.states.get(ent.entity_id)
+    return None
+
+
+def _float(hass: HomeAssistant, entry: MockConfigEntry, suffix: str) -> float:
+    st = _state_obj(hass, entry, suffix)
+    assert st is not None, f"sensor *{suffix} not found"
+    assert st.state not in ("unknown", "unavailable"), f"*{suffix} is {st.state}"
+    return float(st.state)
+
+
+def _grid_with_price() -> dict:
+    grid = copy.deepcopy(make_grid_subentry_data())
+    grid["data"]["adapter"]["config"][
+        "grid_electricity_price_entity"
+    ] = "sensor.grid_price"
+    return grid
+
+
+def _set(hass: HomeAssistant, entity_id: str, value, unit: str | None = "W") -> None:
+    attrs = {"unit_of_measurement": unit} if unit else {}
+    hass.states.async_set(entity_id, str(value), attrs)
+
+
+async def _settle(hass: HomeAssistant) -> None:
+    """Flush the coalesced (call_soon) sensor state writes a few times.
+
+    Post-setup state events propagate engine -> custom event -> sensor write
+    over a couple of event-loop iterations, and the derived combined sensor
+    reads its siblings' already-written states, so several flushes are needed.
+    """
+    for _ in range(4):
+        await hass.async_block_till_done()
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — instantaneous sensor values
+# ---------------------------------------------------------------------------
+
+async def test_e2e_instantaneous_sensor_values(hass: HomeAssistant) -> None:
+    """From config entry to rendered instantaneous sensor states."""
+    pv = copy.deepcopy(make_pv_subentry_data())
+    pv["data"]["adapter"]["config"]["correction_factor"] = 1.5
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My PowerInsight",
+        options={
+            "calculate_instantaneous_rates": [
+                "calculate_cost_rates",
+                "calculate_levelized_cost_rates",
+            ],
+            "calculate_instantaneous_saving_rates": [],
+            "calculate_accumulated_entities": [],
+        },
+        subentries_data=[_grid_with_price(), pv],
+    )
+    _set(hass, "sensor.grid_power", 1000)
+    _set(hass, "sensor.grid_price", 0.30, unit="EUR/kWh")
+    _set(hass, "sensor.pv_power", 2000)
+    await setup_integration(hass, entry)
+    await hass.async_block_till_done()
+
+    # grid import 1 kW * 0.30 = 0.30 EUR/h
+    assert _float(hass, entry, f"{GRID_SUB_ID}_cost_rate") == pytest.approx(0.30)
+    # combined cost rate = grid 0.30 + PV 0.0
+    assert _float(hass, entry, "combined_cost_rate") == pytest.approx(0.30)
+    # combined price = 0.30 / 3 kW gross = 0.10 EUR/kWh
+    assert _float(hass, entry, "combined_price_of_electricity") == pytest.approx(0.10)
+    # corrected levelized rate = grid 0.30*1.0 + PV (2kW*0.10)=0.20 * 1.5 = 0.60
+    # (base would be 0.50 — proves the correction factor flows end-to-end)
+    assert _float(hass, entry, "combined_levelized_cost_rate") == pytest.approx(0.60)
+
+    unit = _state_obj(hass, entry, "combined_cost_rate").attributes.get(
+        "unit_of_measurement"
+    )
+    assert unit == "EUR/h"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — accumulated value over simulated time
+# ---------------------------------------------------------------------------
+
+async def test_e2e_accumulated_value_over_time(hass: HomeAssistant) -> None:
+    """A constant rate held across an hour integrates into the total sensor.
+
+    A constant rate (1 kW import * 0.30 = 0.30 EUR/h) is held and re-reported an
+    hour later, so the trapezoidal step is exact regardless of propagation lag.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My PowerInsight",
+        options={
+            "calculate_instantaneous_rates": ["calculate_cost_rates"],
+            "calculate_instantaneous_saving_rates": [],
+            "calculate_accumulated_entities": ["accumulate_cost_rates"],
+        },
+        subentries_data=[_grid_with_price(), make_pv_subentry_data()],
+    )
+    t0 = dt_util.utcnow()
+    with freeze_time(t0) as frozen:
+        _set(hass, "sensor.grid_power", 1000)
+        _set(hass, "sensor.grid_price", 0.30, unit="EUR/kWh")
+        _set(hass, "sensor.pv_power", 2000)
+        await setup_integration(hass, entry)
+
+        # Anchor the integral at t0 (re-report the unchanged value).
+        _set(hass, "sensor.grid_power", 1000)
+        await _settle(hass)
+
+        # One hour later, re-report and integrate the held 0.30 EUR/h rate.
+        frozen.move_to(t0 + timedelta(hours=1))
+        _set(hass, "sensor.grid_power", 1000)
+        await _settle(hass)
+
+    rate = _float(hass, entry, f"{GRID_SUB_ID}_cost_rate")
+    total = _float(hass, entry, f"{GRID_SUB_ID}_total_cost")
+    assert rate == pytest.approx(0.30)
+    # 0.30 EUR/h held for 1 h = 0.30 EUR.
+    assert total == pytest.approx(0.30, abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — removal-ledger lifecycle
+# ---------------------------------------------------------------------------
+
+async def test_e2e_removal_ledger_lifecycle(hass: HomeAssistant) -> None:
+    """Accumulate, remove the device, and verify the frozen ledger persists."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My PowerInsight",
+        options={
+            "calculate_instantaneous_rates": [],
+            "calculate_instantaneous_saving_rates": [],
+            "calculate_accumulated_entities": ["accumulate_levelized_cost_rates"],
+        },
+        subentries_data=[_grid_with_price(), make_pv_subentry_data()],
+    )
+    t0 = dt_util.utcnow()
+    with freeze_time(t0) as frozen:
+        _set(hass, "sensor.grid_power", 1000)
+        _set(hass, "sensor.grid_price", 0.30, unit="EUR/kWh")
+        _set(hass, "sensor.pv_power", -100)  # constant standby: PV consumes 100 W
+        await setup_integration(hass, entry)
+
+        # Anchor at t0, then integrate the held levelized operating-cost rate
+        # (0.1 kW * 0.30 EUR/kWh = 0.03 EUR/h) over one hour.
+        _set(hass, "sensor.pv_power", -100)
+        await _settle(hass)
+        frozen.move_to(t0 + timedelta(hours=1))
+        _set(hass, "sensor.pv_power", -100)
+        await _settle(hass)
+
+    per_adapter = _float(
+        hass, entry, f"{PV_SUB_ID}_total_levelized_operating_costs"
+    )
+    assert per_adapter == pytest.approx(0.03, abs=1e-3)
+    # The derived combined sensor equals the sum of active per-adapter totals.
+    combined = _float(hass, entry, "combined_total_levelized_operating_costs")
+    assert combined == pytest.approx(per_adapter, abs=1e-6)
+
+    # Remove the PV device. HA clears its entities, whose teardown snapshots
+    # the final levelized total into the ledger (entry.data).
+    hass.config_entries.async_remove_subentry(entry, PV_SUB_ID)
+    await _settle(hass)
+
+    # Each device snapshots its two levelized totals as separate ledger entries;
+    # sum the operating-costs key across them.
+    ledger = entry.data.get("retired_adapters", [])
+    op_total = sum(
+        e.get("totals", {}).get("total_levelized_operating_costs", 0.0)
+        for e in ledger
+    )
+    assert op_total == pytest.approx(per_adapter, abs=1e-6)
+
+    # The frozen contribution persists in the combined total though the PV
+    # device is gone. Re-report a source entity to refresh the derived sensor.
+    _set(hass, "sensor.grid_power", 1000)
+    await _settle(hass)
+    combined_after = _float(hass, entry, "combined_total_levelized_operating_costs")
+    assert combined_after == pytest.approx(per_adapter, abs=1e-6)
+
+    # Reload again: no double-count.
+    await hass.config_entries.async_reload(entry.entry_id)
+    await _settle(hass)
+    _set(hass, "sensor.grid_power", 1000)
+    await _settle(hass)
+    combined_reloaded = _float(
+        hass, entry, "combined_total_levelized_operating_costs"
+    )
+    assert combined_reloaded == pytest.approx(per_adapter, abs=1e-6)


### PR DESCRIPTION
## Summary
This PR implements a correction-factor system for levelized cost calculations and simplifies the configuration flow by moving rate-selection options to the options flow only. It also fixes a bug where levelized cost savings rates returned `None` instead of computed values.

## Key Changes

### Correction Factor System (Items C1-C5)
- **New `correction_factor` field**: Stores the ratio `current_lcoe / default_lcoe` for PV and battery adapters, computed during reconfigure flows
- **Immutable base LCOE**: The `lcoe` property remains the base value; correction is applied only to displayed values
- **Corrected combined rates**: Added `combined_lcoe_rate_corrected`, `combined_lcoo_rate_corrected`, and `combined_levelized_saving_rate_corrected` properties that scale each adapter's contribution by its correction factor
- **Per-adapter levelized display**: Per-adapter levelized sensors now scale their displayed values by the adapter's correction factor via the new `apply_correction_factor` flag
- **Retired-adapter ledger**: Combined accumulated levelized sensors now derive their value from per-adapter base totals (each already scaled by correction factor) plus a persistent ledger of removed devices, ensuring lifetime-value corrections are retroactive and removed devices don't drop their historical contribution

### Config Flow Simplification (Items A1-A3, B1-B2)
- **Options-only rate selection**: Moved `calculate_instantaneous_rates`, `calculate_instantaneous_saving_rates`, and `calculate_accumulated_entities` from the initial config step to options-only, with new defaults (cost-savings rates + accumulated totals for fresh installs)
- **Removed CO₂ options**: Stripped CO₂ intensity and levelized CO₂ intensity options from all three multiselect fields
- **Battery power entity required**: Made the power entity field mandatory for battery adapters
- **Simplified initial step**: The initial config step now only asks for the integration name

### Currency Handling
- **Dynamic currency selectors**: Money and compensation input selectors now use `currency_selector_fn` to build selectors labeled with the configured HA currency code
- **Sensor unit substitution**: Added `_resolve_currency_unit()` helper to replace "EUR" placeholders in sensor units with the configured currency (e.g., "EUR/h" → "USD/h")

### Bug Fixes
- **B4 — Levelized cost savings rates**: Fixed `prod_adapters_levelized_cost_saving_rates` and `storage_adapters_levelized_cost_saving_rates` to return the computed `saving_rates` dict instead of bare `None`
- **Levelized sensors gated on LCOE**: Per-adapter levelized sensors are now only created when the adapter has a configured LCOE (via `exists_fn` check)

### Testing
- **End-to-end tests** (`test_end_to_end.py`): Verify instantaneous sensor values, accumulated values over time, and the removal-ledger lifecycle
- **Correction factor tests** (`test_correction_factor.py`): Engine-level tests for correction factor computation and corrected combined rates
- **Correction flow tests** (`test_correction_flow.py`): Config-flow reconfigure, levelized sensor gating, and correction-factor scaling
- **Currency tests** (`test_currency.py`): Sensor units and config-flow selectors follow the configured currency
- **Config simplification tests** (`test_config_simplification.py`): Verify multiselects are options-only, CO₂ options removed, and battery power entity required

## Implementation Details
- Correction factors are time-constant, so multiplying an accumulated base total by the factor is exact and retroactive
- The combined accumulated ledger sensors use a new `COMBINED_LEDGER_ADAPTER_KEYS` mapping to enumerate which per-adapter keys to sum
- Removed adapters' final corrected values are frozen into a persistent ledger (`CONF_RETIRED_ADAPTERS`) to prevent historical data loss
- Currency substitution is applied at sensor creation time via `_resolve_currency_unit()`, ensuring all monetary units reflect the user's configured currency

https://claude.ai/code/session_01E78jvDXPt2w3ZNsL2H49o4