### PR TITLE
Redesign options flow: per-scope categories and grid sensor consolidation

### DIFF
--- a/custom_components/power_insight/__init__.py
+++ b/custom_components/power_insight/__init__.py
@@ -154,8 +154,60 @@ async def async_unload_entry(
 async def async_migrate_entry(
     hass: HomeAssistant, entry: MyConfigEntry,
 ) -> bool:
-    """Migrate the old config entry to a newer version."""
-    if entry.version > 1:
-        pass
+    """Migrate the config entry to a newer version."""
+    if entry.version == 1 and entry.minor_version < 2:
+        _migrate_options_to_scopes(hass, entry)
 
     return True
+
+
+def _migrate_options_to_scopes(hass: HomeAssistant, entry: MyConfigEntry) -> None:
+    """Convert the old flat options to the v2 per-scope schema.
+
+    Pre-release, so history is not preserved — only behaviour is roughly kept:
+    the old global selection is distributed into each scope, intersected with
+    what that scope supports. See docs/options-flow-redesign.md.
+    """
+    # Imported here to avoid a circular import at module load.
+    from .const import SCOPES, SCOPE_SUPPORTED_OPTIONS
+
+    old = entry.options or {}
+
+    # Already in the v2 per-scope shape (e.g. created by the current flow): just
+    # stamp the version, never rewrite the user's selection.
+    if "scopes" in old:
+        if entry.minor_version != 2:
+            hass.config_entries.async_update_entry(entry, minor_version=2)
+        return
+
+    leaves = set(
+        old.get("calculate_instantaneous_rates", [])
+        + old.get("calculate_instantaneous_saving_rates", [])
+        + old.get("calculate_accumulated_entities", [])
+    )
+    if old.get("enable_power_shares"):
+        leaves |= {
+            "enable_distribution_ratios",
+            "enable_distribution_shares",
+            "enable_charging_source_shares",
+            "enable_power_source_shares",
+        }
+    # Watt sensors were always-on before the redesign — keep them.
+    leaves.add("enable_distribution_power")
+    # Export compensation used to ride on the cost-rate keys.
+    if "calculate_cost_rates" in leaves:
+        leaves.add("enable_export_compensation_rate")
+    if "accumulate_cost_rates" in leaves:
+        leaves.add("accumulate_export_compensation")
+
+    new_options = {
+        "schema": 2,
+        "scopes": {
+            scope: sorted(leaves & SCOPE_SUPPORTED_OPTIONS[scope])
+            for scope in SCOPES
+        },
+        "debug_power_entities": bool(old.get("debug_power_entities", False)),
+    }
+    hass.config_entries.async_update_entry(
+        entry, options=new_options, minor_version=2
+    )

--- a/custom_components/power_insight/config_flow.py
+++ b/custom_components/power_insight/config_flow.py
@@ -45,11 +45,16 @@ from .const import (
     CONF_CHARGE_FROM_GRID,
     CONF_CHARGE_FROM_ADAPTERS,
     CONF_ENABLE_DEBUG_ENTITIES,
-    CONF_ENABLE_POWER_SHARES,
-
-    CONF_CALCULATE_INSTANTANEOUS_RATES,
-    CONF_CALCULATE_INSTANTANEOUS_SAVING_RATES,
-    CONF_CALCULATE_ACCUMULATED_ENTITIES,
+    CONF_ENABLE_DISTRIBUTION_POWER,
+    CONF_ENABLE_DISTRIBUTION_RATIOS,
+    CONF_ENABLE_DISTRIBUTION_SHARES,
+    CONF_ENABLE_CHARGING_SOURCE_SHARES,
+    CONF_ENABLE_POWER_SOURCE_SHARES,
+    CONF_ENABLE_EXPORT_COMPENSATION_RATE,
+    CONF_ACCUMULATE_EXPORT_COMPENSATION,
+    SCOPES,
+    SCOPE_COMBINED,
+    SCOPE_SUPPORTED_OPTIONS,
 
     CONF_CALCULATE_COST_RATES,
     CONF_CALCULATE_LEVELIZED_COST_RATES,
@@ -87,6 +92,10 @@ _COST_OPTIONS = {
     CONF_CALCULATE_LEVELIZED_COST_RATES,
     CONF_CALCULATE_COST_SAVING_RATES,
     CONF_CALCULATE_LEVELIZED_COST_SAVING_RATES,
+    CONF_ACCUMULATE_COST_RATES,
+    CONF_ACCUMULATE_LEVELIZED_COST_RATES,
+    CONF_ACCUMULATE_COST_SAVING_RATES,
+    CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES,
 }
 _CO2_OPTIONS = {
     CONF_CALCULATE_CO2_INTENSITY_RATES,
@@ -97,6 +106,8 @@ _CO2_OPTIONS = {
 _LEVELIZED_COST_OPTIONS = {
     CONF_CALCULATE_LEVELIZED_COST_RATES,
     CONF_CALCULATE_LEVELIZED_COST_SAVING_RATES,
+    CONF_ACCUMULATE_LEVELIZED_COST_RATES,
+    CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES,
 }
 _LEVELIZED_CO2_OPTIONS = {
     CONF_CALCULATE_LEVELIZED_CO2_INTENSITY_RATES,
@@ -105,35 +116,35 @@ _LEVELIZED_CO2_OPTIONS = {
 _COST_SAVING_OPTIONS = {
     CONF_CALCULATE_COST_SAVING_RATES,
     CONF_CALCULATE_LEVELIZED_COST_SAVING_RATES,
+    CONF_ACCUMULATE_COST_SAVING_RATES,
+    CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES,
+    CONF_ENABLE_EXPORT_COMPENSATION_RATE,
+    CONF_ACCUMULATE_EXPORT_COMPENSATION,
 }
 
-def _selected(options: dict, key: str) -> set:
-    val = options.get(key, [])
-    return set(val) if isinstance(val, list) else set()
+
+def _all_enabled_leaves(options: dict) -> set[str]:
+    """Return the union of enabled leaf option keys across every scope."""
+    leaves: set[str] = set()
+    for scope_leaves in options.get("scopes", {}).values():
+        leaves.update(scope_leaves)
+    return leaves
+
 
 def _price_entity_required(options: dict) -> bool:
-    rates = _selected(options, CONF_CALCULATE_INSTANTANEOUS_RATES)
-    saving_rates = _selected(options, CONF_CALCULATE_INSTANTANEOUS_SAVING_RATES)
-    return bool((rates | saving_rates) & _COST_OPTIONS)
+    return bool(_all_enabled_leaves(options) & _COST_OPTIONS)
 
 def _co2_entity_required(options: dict) -> bool:
-    rates = _selected(options, CONF_CALCULATE_INSTANTANEOUS_RATES)
-    saving_rates = _selected(options, CONF_CALCULATE_INSTANTANEOUS_SAVING_RATES)
-    return bool((rates | saving_rates) & _CO2_OPTIONS)
+    return bool(_all_enabled_leaves(options) & _CO2_OPTIONS)
 
 def _export_compensation_required(options: dict) -> bool:
-    saving_rates = _selected(options, CONF_CALCULATE_INSTANTANEOUS_SAVING_RATES)
-    return bool(saving_rates & _COST_SAVING_OPTIONS)
+    return bool(_all_enabled_leaves(options) & _COST_SAVING_OPTIONS)
 
 def _levelized_cost_required(options: dict) -> bool:
-    rates = _selected(options, CONF_CALCULATE_INSTANTANEOUS_RATES)
-    saving_rates = _selected(options, CONF_CALCULATE_INSTANTANEOUS_SAVING_RATES)
-    return bool((rates | saving_rates) & _LEVELIZED_COST_OPTIONS)
+    return bool(_all_enabled_leaves(options) & _LEVELIZED_COST_OPTIONS)
 
 def _levelized_co2_required(options: dict) -> bool:
-    rates = _selected(options, CONF_CALCULATE_INSTANTANEOUS_RATES)
-    saving_rates = _selected(options, CONF_CALCULATE_INSTANTANEOUS_SAVING_RATES)
-    return bool((rates | saving_rates) & _LEVELIZED_CO2_OPTIONS)
+    return bool(_all_enabled_leaves(options) & _LEVELIZED_CO2_OPTIONS)
 
 def _levelized_production_required(options: dict) -> bool:
     return _levelized_cost_required(options) or _levelized_co2_required(options)
@@ -393,107 +404,141 @@ def make_compensation_selector(currency: str) -> selector.NumberSelector:
         )
     )
 
-INSTANTANEOUS_RATES_SELECTOR = selector.SelectSelector(
-    selector.SelectSelectorConfig(
-        options=[
-            selector.SelectOptionDict(
-                value=CONF_CALCULATE_COST_RATES, label="Cost"
-            ),
-            selector.SelectOptionDict(
-                value=CONF_CALCULATE_LEVELIZED_COST_RATES, label="Levelized costs"
-            ),
-        ],
-        mode=selector.SelectSelectorMode.LIST,
-        multiple=True,
-    )
-)
-
-INSTANTANEOUS_SAVING_RATES_SELECTOR = selector.SelectSelector(
-    selector.SelectSelectorConfig(
-        options=[
-            selector.SelectOptionDict(
-                value=CONF_CALCULATE_COST_SAVING_RATES, label="Cost savings rate"
-            ),
-            selector.SelectOptionDict(
-                value=CONF_CALCULATE_LEVELIZED_COST_SAVING_RATES, label="Levelized cost savings rate"
-            ),
-        ],
-        mode=selector.SelectSelectorMode.LIST,
-        multiple=True,
-    )
-)
-
-ACCUMULATED_ENTITIES_SELECTOR = selector.SelectSelector(
-    selector.SelectSelectorConfig(
-        options=[
-            selector.SelectOptionDict(
-                value=CONF_ACCUMULATE_COST_RATES, label="Cost rate"
-            ),
-            selector.SelectOptionDict(
-                value=CONF_ACCUMULATE_LEVELIZED_COST_RATES, label="Levelized cost rate"
-            ),
-            selector.SelectOptionDict(
-                value=CONF_ACCUMULATE_COST_SAVING_RATES, label="Cost savings rate"
-            ),
-            selector.SelectOptionDict(
-                value=CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES, label="Levelized cost savings rate"
-            ),
-        ],
-        mode=selector.SelectSelectorMode.LIST,
-        multiple=True,
-    )
-)
-
-
 # ============================================================================
-# CONFIG FIELDS
+# OPTION CATEGORIES  (per-scope options flow)
 #
-# in_config_flow=True  → shown during initial setup (async_step_user)
-# in_options_flow=True → shown in the options flow
+# Sensor selection is grouped into human-readable categories, each mapping to
+# one or more leaf option keys. A category is shown in a scope only when that
+# scope supports at least one of its leaves (SCOPE_SUPPORTED_OPTIONS). See
+# docs/options-flow-redesign.md.
 # ============================================================================
 
-CONFIG_ENTRY_FIELDS: dict[str, EntryField] = {
-    # --- Shown in both initial config and options flow ---
-    # Moved to options-only so the initial config step asks for the name only.
-    # Fresh installs default to cost-savings rates + accumulated totals.
-    CONF_CALCULATE_INSTANTANEOUS_RATES: EntryField(
-        selector=INSTANTANEOUS_RATES_SELECTOR,
-        required=True,
-        default=[],
-        in_config_flow=False,
-        in_options_flow=True,
-    ),
-    CONF_CALCULATE_INSTANTANEOUS_SAVING_RATES: EntryField(
-        selector=INSTANTANEOUS_SAVING_RATES_SELECTOR,
-        required=True,
-        default=[CONF_CALCULATE_COST_SAVING_RATES],
-        in_config_flow=False,
-        in_options_flow=True,
-    ),
-    CONF_CALCULATE_ACCUMULATED_ENTITIES: EntryField(
-        selector=ACCUMULATED_ENTITIES_SELECTOR,
-        required=True,
-        default=[CONF_ACCUMULATE_COST_SAVING_RATES],
-        in_config_flow=False,
-        in_options_flow=True,
-    ),
+@dataclass(frozen=True)
+class OptionCategory:
+    """A user-facing options category mapped to one or more leaf option keys."""
 
-    CONF_ENABLE_POWER_SHARES: EntryField(
-        selector=BOOLEAN_SELECTOR,
-        required=True,
-        default=True,
-        in_config_flow=False,
-        in_options_flow=True,
+    field: str
+    leaves: tuple[tuple[str, str], ...]   # (leaf_key, choice_label)
+    toggle: bool = False                  # True → single boolean leaf
+
+
+OPTION_CATEGORIES: tuple[OptionCategory, ...] = (
+    OptionCategory(
+        "distribution_power", ((CONF_ENABLE_DISTRIBUTION_POWER, ""),), toggle=True
     ),
-    # --- Options flow only ---
-    CONF_ENABLE_DEBUG_ENTITIES: EntryField(
-        selector=BOOLEAN_SELECTOR,
-        required=True,
-        default=False,
-        in_config_flow=False,
-        in_options_flow=True,
+    OptionCategory("cost_rates", (
+        (CONF_CALCULATE_COST_RATES, "Cost"),
+        (CONF_CALCULATE_LEVELIZED_COST_RATES, "Levelized cost"),
+    )),
+    OptionCategory("cost_savings_rates", (
+        (CONF_CALCULATE_COST_SAVING_RATES, "Cost savings"),
+        (CONF_CALCULATE_LEVELIZED_COST_SAVING_RATES, "Levelized cost savings"),
+    )),
+    OptionCategory("export_compensation", (
+        (CONF_ENABLE_EXPORT_COMPENSATION_RATE, "Rate"),
+        (CONF_ACCUMULATE_EXPORT_COMPENSATION, "Accumulated total"),
+    )),
+    OptionCategory("accumulated_costs", (
+        (CONF_ACCUMULATE_COST_RATES, "Cost"),
+        (CONF_ACCUMULATE_LEVELIZED_COST_RATES, "Levelized cost"),
+    )),
+    OptionCategory("accumulated_cost_savings", (
+        (CONF_ACCUMULATE_COST_SAVING_RATES, "Cost savings"),
+        (CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES, "Levelized cost savings"),
+    )),
+    OptionCategory(
+        "distribution_ratios", ((CONF_ENABLE_DISTRIBUTION_RATIOS, ""),), toggle=True
     ),
+    OptionCategory(
+        "distribution_shares", ((CONF_ENABLE_DISTRIBUTION_SHARES, ""),), toggle=True
+    ),
+    OptionCategory(
+        "charging_source_shares",
+        ((CONF_ENABLE_CHARGING_SOURCE_SHARES, ""),), toggle=True,
+    ),
+    OptionCategory(
+        "power_source_shares",
+        ((CONF_ENABLE_POWER_SOURCE_SHARES, ""),), toggle=True,
+    ),
+)
+
+# Fresh-install default selection (intersected per scope with its support).
+DEFAULT_SELECTION: set[str] = {
+    CONF_CALCULATE_COST_SAVING_RATES,
+    CONF_ACCUMULATE_COST_SAVING_RATES,
+    CONF_ENABLE_EXPORT_COMPENSATION_RATE,
+    CONF_ACCUMULATE_EXPORT_COMPENSATION,
+    CONF_ENABLE_DISTRIBUTION_POWER,
+    CONF_ENABLE_DISTRIBUTION_RATIOS,
+    CONF_ENABLE_DISTRIBUTION_SHARES,
+    CONF_ENABLE_CHARGING_SOURCE_SHARES,
+    CONF_ENABLE_POWER_SOURCE_SHARES,
 }
+
+
+def default_scopes() -> dict[str, list[str]]:
+    """Return the per-scope default selection, intersected with scope support."""
+    return {
+        scope: sorted(DEFAULT_SELECTION & SCOPE_SUPPORTED_OPTIONS[scope])
+        for scope in SCOPES
+    }
+
+
+def _scope_category(category: OptionCategory, scope: str):
+    """Return (supported leaves, selector) for *category* in *scope*, or None."""
+    supported = [
+        (leaf, label) for leaf, label in category.leaves
+        if leaf in SCOPE_SUPPORTED_OPTIONS[scope]
+    ]
+    if not supported:
+        return None
+    if category.toggle:
+        return supported, BOOLEAN_SELECTOR
+    return supported, selector.SelectSelector(
+        selector.SelectSelectorConfig(
+            options=[
+                selector.SelectOptionDict(value=leaf, label=label)
+                for leaf, label in supported
+            ],
+            mode=selector.SelectSelectorMode.LIST,
+            multiple=True,
+        )
+    )
+
+
+def build_scope_schema(scope: str, current: set[str]) -> vol.Schema:
+    """Build the options form schema for one scope."""
+    fields: dict = {}
+    for category in OPTION_CATEGORIES:
+        resolved = _scope_category(category, scope)
+        if resolved is None:
+            continue
+        supported, sel = resolved
+        if category.toggle:
+            leaf = supported[0][0]
+            fields[vol.Required(category.field, default=leaf in current)] = sel
+        else:
+            default = [leaf for leaf, _ in supported if leaf in current]
+            fields[vol.Optional(category.field, default=default)] = sel
+    return vol.Schema(fields)
+
+
+def collect_scope_selection(scope: str, user_input: dict) -> list[str]:
+    """Turn a scope form submission into a sorted list of enabled leaf keys."""
+    selected: set[str] = set()
+    for category in OPTION_CATEGORIES:
+        resolved = _scope_category(category, scope)
+        if resolved is None:
+            continue
+        supported, _ = resolved
+        if category.field not in user_input:
+            continue
+        if category.toggle:
+            if user_input[category.field]:
+                selected.add(supported[0][0])
+        else:
+            selected.update(user_input[category.field])
+    return sorted(selected)
 
 
 # ============================================================================
@@ -1095,15 +1140,21 @@ def check_options_feasibility(
     An empty list means all subentries already satisfy the new requirements.
     """
     needs_reconfigure = []
-
-    calc_cost = _price_entity_required(new_options)
-    calc_co2 = _co2_entity_required(new_options)
-    levelized = _levelized_production_required(new_options)
+    scopes = new_options.get("scopes", {})
 
     for subentry in entry.subentries.values():
         adapter = subentry.data.get("adapter", {})
         adapter_type = adapter.get("adapter_type")
         config = adapter.get("config", {})
+
+        # A device needs data when the category is enabled in its own scope or
+        # in the combined scope (combined sensors aggregate the device).
+        enabled = set(scopes.get(adapter_type, [])) | set(
+            scopes.get(SCOPE_COMBINED, [])
+        )
+        calc_cost = bool(enabled & _COST_OPTIONS)
+        calc_co2 = bool(enabled & _CO2_OPTIONS)
+        levelized = bool(enabled & (_LEVELIZED_COST_OPTIONS | _LEVELIZED_CO2_OPTIONS))
 
         if adapter_type == "grid":
             missing = (
@@ -1143,52 +1194,37 @@ class PowerInsightConfigFlow(ConfigFlow, domain=DOMAIN):
     """
 
     VERSION = 1
-    MINOR_VERSION = 1
+    MINOR_VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Collect the integration title and initial options."""
+        """Collect the integration title and seed the default per-scope options."""
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            title = user_input.pop(CONF_NAME, "").strip()
+            title = user_input.get(CONF_NAME, "").strip()
             if not title:
                 errors[CONF_NAME] = "invalid_name"
             else:
-                # The initial form only collects the name, so seed the entry
-                # options from the options-flow field defaults (cost-savings
-                # rates + accumulated totals) and let any config-visible input
-                # override them. This guarantees fresh installs register the
-                # default sensors before the user opens the options flow.
-                option_defaults: dict[str, Any] = {
-                    fn: fd.default
-                    for fn, fd in CONFIG_ENTRY_FIELDS.items()
-                    if fd.in_options_flow and fd.default is not vol.UNDEFINED
-                }
-                option_defaults.update(user_input)
+                # The initial form only collects the name; seed the per-scope
+                # default selection so fresh installs register sensible sensors
+                # before the user opens the options flow.
                 return self.async_create_entry(
                     title=title,
                     data={},
-                    options=option_defaults,
+                    options={
+                        "schema": 2,
+                        "scopes": default_scopes(),
+                        CONF_ENABLE_DEBUG_ENTITIES: False,
+                    },
                 )
-
-        # Seed defaults from the config-visible subset of CONFIG_ENTRY_FIELDS
-        defaults: dict[str, Any] = {
-            fn: fd.default
-            for fn, fd in CONFIG_ENTRY_FIELDS.items()
-            if fd.in_config_flow and fd.default is not vol.UNDEFINED
-        }
-        if user_input:
-            defaults.update(user_input)
-
-        name_part: dict = {vol.Required(CONF_NAME, default=""): TEXT_SELECTOR}
-        options_part = build_schema(CONFIG_ENTRY_FIELDS, "config", defaults).schema
-        combined = vol.Schema({**name_part, **options_part})
 
         return self.async_show_form(
             step_id="user",
-            data_schema=combined,
+            data_schema=vol.Schema(
+                {vol.Required(CONF_NAME, default=""): TEXT_SELECTOR}
+            ),
             errors=errors,
         )
 
@@ -1474,49 +1510,121 @@ class AdapterSubentryFlow(ConfigSubentryFlow):
 # ============================================================================
 
 class PowerInsightOptionsFlow(OptionsFlow):
-    """Options flow for Power Insight.
+    """Per-scope options flow.
 
-    Exposes all option fields; validates that enabling a new option does not
-    require data that existing adapter subentries have not yet provided.
+    A menu offers the whole-home (combined) scope plus one section per
+    configured device type, then a diagnostics section and a save action. Each
+    section edits only the categories that scope supports. The working
+    selection is accumulated across steps and written on save.
     """
+
+    def __init__(self) -> None:
+        """Initialise the working selection lazily."""
+        self._scopes: dict[str, set[str]] | None = None
+        self._debug: bool = False
+
+    def _load(self) -> None:
+        """Load the working selection from the stored options once."""
+        if self._scopes is not None:
+            return
+        options = self.config_entry.options
+        stored = options.get("scopes", {})
+        self._scopes = {scope: set(stored.get(scope, [])) for scope in SCOPES}
+        self._debug = bool(options.get(CONF_ENABLE_DEBUG_ENTITIES, False))
+
+    def _present_device_scopes(self) -> list[str]:
+        """Return device-type scopes that have at least one subentry."""
+        types = {
+            sub.data.get("adapter", {}).get("adapter_type")
+            for sub in self.config_entry.subentries.values()
+        }
+        return [t for t in ("grid", "pv_system", "battery", "consumer") if t in types]
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        errors: dict[str, str] = {}
-        needs_reconfigure: list[str] = []
-
-        if user_input is not None:
-            needs_reconfigure = check_options_feasibility(
-                self.config_entry, user_input
-            )
-            if needs_reconfigure:
-                errors["base"] = "reconfigure_adapters_first"
-            else:
-                return self.async_create_entry(title="", data=user_input)
-
-        # Build current values: defaults → saved options → in-progress input
-        current: dict[str, Any] = {
-            fn: fd.default
-            for fn, fd in CONFIG_ENTRY_FIELDS.items()
-            if fd.default is not vol.UNDEFINED
-        }
-        current.update(self.config_entry.options)
-        if user_input:
-            current.update(user_input)
-            # Recompute needs_reconfigure for placeholder when re-showing form
-            needs_reconfigure = check_options_feasibility(
-                self.config_entry, user_input
-            )
-
-        schema = build_schema(CONFIG_ENTRY_FIELDS, "options", current)
-
-        return self.async_show_form(
+        """Show the section menu."""
+        self._load()
+        return self.async_show_menu(
             step_id="init",
-            data_schema=schema,
-            errors=errors,
-            description_placeholders={
-                # Translation string can reference {adapters_needing_reconfigure}
-                "adapters_needing_reconfigure": ", ".join(needs_reconfigure) or "—",
-            },
+            menu_options=[
+                SCOPE_COMBINED,
+                *self._present_device_scopes(),
+                "diagnostics",
+                "save",
+            ],
         )
+
+    async def _async_scope_step(
+        self, scope: str, user_input: dict[str, Any] | None
+    ) -> FlowResult:
+        """Render / collect one scope's category selection."""
+        self._load()
+        if user_input is not None:
+            self._scopes[scope] = set(collect_scope_selection(scope, user_input))
+            return await self.async_step_init()
+        return self.async_show_form(
+            step_id=scope,
+            data_schema=build_scope_schema(scope, self._scopes[scope]),
+        )
+
+    async def async_step_combined(self, user_input=None) -> FlowResult:
+        """Edit the whole-home (combined) scope."""
+        return await self._async_scope_step(SCOPE_COMBINED, user_input)
+
+    async def async_step_grid(self, user_input=None) -> FlowResult:
+        """Edit the grid scope."""
+        return await self._async_scope_step("grid", user_input)
+
+    async def async_step_pv_system(self, user_input=None) -> FlowResult:
+        """Edit the PV-system scope."""
+        return await self._async_scope_step("pv_system", user_input)
+
+    async def async_step_battery(self, user_input=None) -> FlowResult:
+        """Edit the battery scope."""
+        return await self._async_scope_step("battery", user_input)
+
+    async def async_step_consumer(self, user_input=None) -> FlowResult:
+        """Edit the consumer scope."""
+        return await self._async_scope_step("consumer", user_input)
+
+    async def async_step_diagnostics(self, user_input=None) -> FlowResult:
+        """Edit the global diagnostics toggle."""
+        self._load()
+        if user_input is not None:
+            self._debug = bool(user_input.get(CONF_ENABLE_DEBUG_ENTITIES, False))
+            return await self.async_step_init()
+        return self.async_show_form(
+            step_id="diagnostics",
+            data_schema=vol.Schema({
+                vol.Required(
+                    CONF_ENABLE_DEBUG_ENTITIES, default=self._debug
+                ): BOOLEAN_SELECTOR,
+            }),
+        )
+
+    def _compose(self) -> dict:
+        """Build the options dict from the working selection."""
+        return {
+            "schema": 2,
+            "scopes": {scope: sorted(self._scopes[scope]) for scope in SCOPES},
+            CONF_ENABLE_DEBUG_ENTITIES: self._debug,
+        }
+
+    async def async_step_save(self, user_input=None) -> FlowResult:
+        """Validate against existing adapters and persist the options."""
+        self._load()
+        new_options = self._compose()
+        problems = check_options_feasibility(self.config_entry, new_options)
+        if problems and user_input is None:
+            # Some devices lack data the new options need. Warn, but let the
+            # user confirm (submit) to apply anyway, then reconfigure them.
+            return self.async_show_form(
+                step_id="save",
+                data_schema=vol.Schema({}),
+                errors={"base": "reconfigure_adapters_first"},
+                description_placeholders={
+                    "adapters_needing_reconfigure": ", ".join(problems),
+                },
+            )
+        return self.async_create_entry(title="", data=new_options)

--- a/custom_components/power_insight/const.py
+++ b/custom_components/power_insight/const.py
@@ -69,7 +69,20 @@ CONF_CALCULATE_INSTANTANEOUS_SAVING_RATES = "calculate_instantaneous_saving_rate
 CONF_CALCULATE_ACCUMULATED_ENTITIES = "calculate_accumulated_entities"
 
 CONF_ENABLE_DEBUG_ENTITIES = "debug_power_entities"
+# Legacy combined power-share toggle (pre-redesign); kept only so the options
+# migration can read it. Superseded by the distribution/share keys below.
 CONF_ENABLE_POWER_SHARES = "enable_power_shares"
+
+# Power-distribution categories (replace CONF_ENABLE_POWER_SHARES)
+CONF_ENABLE_DISTRIBUTION_POWER = "enable_distribution_power"      # watt split
+CONF_ENABLE_DISTRIBUTION_RATIOS = "enable_distribution_ratios"    # *_ratio %
+CONF_ENABLE_DISTRIBUTION_SHARES = "enable_distribution_shares"    # *_share %
+CONF_ENABLE_CHARGING_SOURCE_SHARES = "enable_charging_source_shares"  # battery
+CONF_ENABLE_POWER_SOURCE_SHARES = "enable_power_source_shares"        # consumer
+
+# Export compensation (split out of the cost-rate / accumulate-cost keys)
+CONF_ENABLE_EXPORT_COMPENSATION_RATE = "enable_export_compensation_rate"
+CONF_ACCUMULATE_EXPORT_COMPENSATION = "accumulate_export_compensation"
 
 CONF_CALCULATE_COST_RATES = "calculate_cost_rates"
 CONF_CALCULATE_LEVELIZED_COST_RATES = "calculate_levelized_cost_rates"
@@ -91,6 +104,79 @@ CONF_ACCUMULATE_COST_SAVING_RATES = "accumulate_cost_saving_rates"
 CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES = "accumulate_levelized_cost_saving_rates"
 CONF_ACCUMULATE_CO2_SAVING_RATES = "accumulate_co2_saving_rates"
 CONF_ACCUMULATE_LEVELIZED_CO2_SAVING_RATES = "accumulate_levelized_co2_saving_rates"
+
+
+# ---------------------------------------------------------------------------
+# Option scopes
+#
+# Sensor selection is configured per scope: the whole-home aggregate
+# ("combined") plus one scope per device type. Each scope only offers the leaf
+# options that its sensors support. Stored as entry.options["scopes"][scope] =
+# [enabled leaf keys]; see docs/options-flow-redesign.md.
+# ---------------------------------------------------------------------------
+
+SCOPE_COMBINED = "combined"
+SCOPES = (SCOPE_COMBINED, "grid", "pv_system", "battery", "consumer")
+
+SCOPE_SUPPORTED_OPTIONS: dict[str, set[str]] = {
+    SCOPE_COMBINED: {
+        CONF_CALCULATE_COST_RATES,
+        CONF_CALCULATE_LEVELIZED_COST_RATES,
+        CONF_CALCULATE_COST_SAVING_RATES,
+        CONF_CALCULATE_LEVELIZED_COST_SAVING_RATES,
+        CONF_ACCUMULATE_COST_RATES,
+        CONF_ACCUMULATE_LEVELIZED_COST_RATES,
+        CONF_ACCUMULATE_COST_SAVING_RATES,
+        CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES,
+        CONF_ENABLE_DISTRIBUTION_POWER,
+        CONF_ENABLE_DISTRIBUTION_RATIOS,
+    },
+    "grid": {
+        CONF_CALCULATE_COST_RATES,
+        CONF_ACCUMULATE_COST_RATES,
+        CONF_ENABLE_EXPORT_COMPENSATION_RATE,
+        CONF_ACCUMULATE_EXPORT_COMPENSATION,
+        CONF_ENABLE_DISTRIBUTION_POWER,
+        CONF_ENABLE_DISTRIBUTION_RATIOS,
+        CONF_ENABLE_DISTRIBUTION_SHARES,
+    },
+    "pv_system": {
+        CONF_CALCULATE_COST_RATES,
+        CONF_CALCULATE_LEVELIZED_COST_RATES,
+        CONF_CALCULATE_COST_SAVING_RATES,
+        CONF_CALCULATE_LEVELIZED_COST_SAVING_RATES,
+        CONF_ENABLE_EXPORT_COMPENSATION_RATE,
+        CONF_ACCUMULATE_EXPORT_COMPENSATION,
+        CONF_ACCUMULATE_COST_RATES,
+        CONF_ACCUMULATE_LEVELIZED_COST_RATES,
+        CONF_ACCUMULATE_COST_SAVING_RATES,
+        CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES,
+        CONF_ENABLE_DISTRIBUTION_POWER,
+        CONF_ENABLE_DISTRIBUTION_RATIOS,
+        CONF_ENABLE_DISTRIBUTION_SHARES,
+    },
+    "battery": {
+        CONF_CALCULATE_COST_RATES,
+        CONF_CALCULATE_LEVELIZED_COST_RATES,
+        CONF_CALCULATE_COST_SAVING_RATES,
+        CONF_CALCULATE_LEVELIZED_COST_SAVING_RATES,
+        CONF_ENABLE_EXPORT_COMPENSATION_RATE,
+        CONF_ACCUMULATE_EXPORT_COMPENSATION,
+        CONF_ACCUMULATE_COST_RATES,
+        CONF_ACCUMULATE_LEVELIZED_COST_RATES,
+        CONF_ACCUMULATE_COST_SAVING_RATES,
+        CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES,
+        CONF_ENABLE_DISTRIBUTION_POWER,
+        CONF_ENABLE_DISTRIBUTION_RATIOS,
+        CONF_ENABLE_DISTRIBUTION_SHARES,
+        CONF_ENABLE_CHARGING_SOURCE_SHARES,
+    },
+    "consumer": {
+        CONF_CALCULATE_COST_RATES,
+        CONF_CALCULATE_LEVELIZED_COST_RATES,
+        CONF_ENABLE_POWER_SOURCE_SHARES,
+    },
+}
 
 
 

--- a/custom_components/power_insight/power_insight.py
+++ b/custom_components/power_insight/power_insight.py
@@ -82,6 +82,10 @@ class PowerInsight:
 
     def __init__(self) -> None:
         """Initialize instance."""
+        # Exactly one grid per entry, by design: one config entry models one
+        # energy mix at a single grid connection. Multiple grid connections are
+        # modelled as multiple config entries, so this stays a singular slot
+        # (the config flow enforces it via the ``grid_already_configured`` guard).
         self.grid_adapter = None
         self.pv_system_adapters = PvSystemAdapters()
         self.storage_adapters = BatteryAdapters()
@@ -749,6 +753,15 @@ class PowerInsight:
         if (coe := self.grid_adapter.coe) is None:
             return {self.grid_adapter.uid: None}
         return {self.grid_adapter.uid: (import_power / 1000) * coe}
+
+    @property
+    def grid_adapters_export_compensation_rate(self) -> dict[str, float | None]:
+        """Return the grid export compensation rate (EUR/h) keyed by uid.
+
+        Export physically happens at the (single) grid connection, so the
+        combined export compensation is surfaced on the grid device.
+        """
+        return {self.grid_adapter.uid: self.combined_export_compensation_rate}
 
     @property
     def grid_adapters_charging_shares(self) -> dict[str, float]:

--- a/custom_components/power_insight/sensor.py
+++ b/custom_components/power_insight/sensor.py
@@ -102,19 +102,6 @@ POWER_INSIGHT_SENSORS = (
         transform_fn=lambda val: val * 100,
     ),
     PowerInsightSensorDescription(
-        key="combined_export_compensation_rate",
-        name="Combined export compensation rate",
-        icon="mdi:currency-eur",
-        native_unit_of_measurement="EUR/h",
-        state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=2,
-        entities_fn=lambda obj: (
-            obj.source_entities_price + obj.source_entities_power
-        ),
-        exists_fn=lambda options: options.check(CONF_CALCULATE_COST_RATES),
-        value_fn=lambda obj: obj.combined_export_compensation_rate,
-    ),
-    PowerInsightSensorDescription(
         key="combined_self_consumption_power",
         name="Combined self-consumption power",
         native_unit_of_measurement=UnitOfPower.WATT,
@@ -292,19 +279,6 @@ POWER_INSIGHT_SENSORS = (
 
 POWER_INSIGHT_INTEGRATION_SENSORS = (
     PowerInsightIntegrationSensorDescription(
-        key="combined_total_export_compensation",
-        name="Combined total export compensation",
-        native_unit_of_measurement="EUR",
-        state_class=SensorStateClass.TOTAL,
-        device_class=SensorDeviceClass.MONETARY,
-        suggested_display_precision=2,
-        entities_fn=lambda obj: (
-            obj.source_entities_price + obj.source_entities_power
-        ),
-        exists_fn=lambda options: options.check(CONF_ACCUMULATE_COST_RATES),
-        integration_value_fn=lambda obj: obj.combined_export_compensation_rate,
-    ),
-    PowerInsightIntegrationSensorDescription(
         key="combined_total_operating_costs",
         name="Combined total operating costs",
         native_unit_of_measurement="EUR",
@@ -404,6 +378,28 @@ POWER_INSIGHT_COMBINED_LEDGER_SENSORS = (
 # ---------------------------------------------------------------------------
 
 POWER_INSIGHT_GRID_ADAPTER_SENSORS = (
+    # Import / export both physically happen at the (single) grid connection,
+    # so the grid device owns both sides of the meter.
+    PowerInsightSensorDescription(
+        key="import_power",
+        name="Import power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        suggested_display_precision=0,
+        entities_fn=lambda obj: obj.source_entities_power,
+        value_fn=lambda obj: obj.grid_adapters_import_power,
+    ),
+    PowerInsightSensorDescription(
+        key="export_power",
+        name="Export power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        suggested_display_precision=0,
+        entities_fn=lambda obj: obj.source_entities_power,
+        value_fn=lambda obj: obj.grid_adapters_export_power,
+    ),
     PowerInsightSensorDescription(
         key="cost_rate",
         name="Cost rate",
@@ -414,6 +410,16 @@ POWER_INSIGHT_GRID_ADAPTER_SENSORS = (
         entities_fn=lambda obj: obj.source_entities_price + obj.source_entities_power,
         exists_fn=lambda options: options.check(CONF_CALCULATE_COST_RATES),
         value_fn=lambda obj: obj.grid_adapters_coe_rate,
+    ),
+    PowerInsightSensorDescription(
+        key="export_compensation_rate",
+        name="Export compensation rate",
+        icon="mdi:currency-eur",
+        native_unit_of_measurement="EUR/h",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: obj.source_entities_price + obj.source_entities_power,
+        value_fn=lambda obj: obj.grid_adapters_export_compensation_rate,
     ),
     PowerInsightSensorDescription(
         key="consumption_ratio",
@@ -495,6 +501,16 @@ POWER_INSIGHT_GRID_ADAPTER_INTEGRATION_SENSORS = (
         entities_fn=lambda obj: obj.source_entities_price + obj.source_entities_power,
         exists_fn=lambda options: options.check(CONF_ACCUMULATE_COST_RATES),
         integration_value_fn=lambda obj: obj.grid_adapters_coe_rate,
+    ),
+    PowerInsightIntegrationSensorDescription(
+        key="total_export_compensation",
+        name="Total export compensation",
+        native_unit_of_measurement="EUR",
+        state_class=SensorStateClass.TOTAL,
+        device_class=SensorDeviceClass.MONETARY,
+        suggested_display_precision=2,
+        entities_fn=lambda obj: obj.source_entities_price + obj.source_entities_power,
+        integration_value_fn=lambda obj: obj.grid_adapters_export_compensation_rate,
     ),
 )
 

--- a/custom_components/power_insight/sensor.py
+++ b/custom_components/power_insight/sensor.py
@@ -32,8 +32,15 @@ from .power_insight import PowerInsight, AbstractBaseAdapter
 from . import MyConfigEntry
 from .const import (
     DOMAIN,
+    SCOPE_COMBINED,
     CONF_ENABLE_DEBUG_ENTITIES,
-    CONF_ENABLE_POWER_SHARES,
+    CONF_ENABLE_DISTRIBUTION_POWER,
+    CONF_ENABLE_DISTRIBUTION_RATIOS,
+    CONF_ENABLE_DISTRIBUTION_SHARES,
+    CONF_ENABLE_CHARGING_SOURCE_SHARES,
+    CONF_ENABLE_POWER_SOURCE_SHARES,
+    CONF_ENABLE_EXPORT_COMPENSATION_RATE,
+    CONF_ACCUMULATE_EXPORT_COMPENSATION,
     CONF_CALCULATE_COST_RATES,
     CONF_CALCULATE_LEVELIZED_COST_RATES,
     CONF_CALCULATE_COST_SAVING_RATES,
@@ -87,7 +94,6 @@ POWER_INSIGHT_SENSORS = (
         device_class=SensorDeviceClass.POWER,
         suggested_display_precision=0,
         entities_fn=lambda obj: obj.source_entities_power,
-        exists_fn=lambda options: options.check(CONF_ENABLE_DEBUG_ENTITIES),
         value_fn=lambda obj: obj.gross_power,
     ),
     PowerInsightSensorDescription(
@@ -132,7 +138,6 @@ POWER_INSIGHT_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        exists_fn=lambda options: options.check(CONF_CALCULATE_COST_SAVING_RATES),
         value_fn=lambda obj: obj.combined_avoided_cost_rate,
     ),
     PowerInsightSensorDescription(
@@ -209,7 +214,6 @@ POWER_INSIGHT_SENSORS = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
         entities_fn=lambda obj: obj.source_entities_power,
-        exists_fn=lambda options: options.check(CONF_CALCULATE_COST_RATES),
         value_fn=lambda obj: obj.combined_coe_rate,
     ),
     PowerInsightSensorDescription(
@@ -220,7 +224,6 @@ POWER_INSIGHT_SENSORS = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
         entities_fn=lambda obj: obj.source_entities_power,
-        exists_fn=lambda options: options.check(CONF_CALCULATE_LEVELIZED_COST_RATES),
         value_fn=lambda obj: obj.combined_lcoe_rate_corrected,
     ),
     PowerInsightSensorDescription(
@@ -233,7 +236,6 @@ POWER_INSIGHT_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        exists_fn=lambda options: options.check(CONF_CALCULATE_COST_RATES),
         value_fn=lambda obj: obj.combined_coo_rate,
     ),
     PowerInsightSensorDescription(
@@ -246,7 +248,6 @@ POWER_INSIGHT_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        exists_fn=lambda options: options.check(CONF_CALCULATE_LEVELIZED_COST_RATES),
         value_fn=lambda obj: obj.combined_lcoo_rate_corrected,
     ),
     PowerInsightSensorDescription(
@@ -259,7 +260,6 @@ POWER_INSIGHT_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        exists_fn=lambda options: options.check(CONF_CALCULATE_COST_SAVING_RATES),
         value_fn=lambda obj: obj.combined_saving_rate,
     ),
     PowerInsightSensorDescription(
@@ -272,7 +272,6 @@ POWER_INSIGHT_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        exists_fn=lambda options: options.check(CONF_CALCULATE_LEVELIZED_COST_SAVING_RATES),
         value_fn=lambda obj: obj.combined_levelized_saving_rate_corrected,
     ),
 )
@@ -288,7 +287,6 @@ POWER_INSIGHT_INTEGRATION_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        exists_fn=lambda options: options.check(CONF_ACCUMULATE_COST_RATES),
         integration_value_fn=lambda obj: obj.combined_coo_rate,
     ),
     PowerInsightIntegrationSensorDescription(
@@ -301,7 +299,6 @@ POWER_INSIGHT_INTEGRATION_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        exists_fn=lambda options: options.check(CONF_ACCUMULATE_COST_SAVING_RATES),
         integration_value_fn=lambda obj: obj.combined_avoided_cost_rate,
     ),
     PowerInsightIntegrationSensorDescription(
@@ -314,7 +311,6 @@ POWER_INSIGHT_INTEGRATION_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        exists_fn=lambda options: options.check(CONF_ACCUMULATE_COST_SAVING_RATES),
         integration_value_fn=lambda obj: obj.combined_saving_rate,
     ),
 )
@@ -354,7 +350,6 @@ POWER_INSIGHT_COMBINED_LEDGER_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        exists_fn=lambda options: options.check(CONF_ACCUMULATE_LEVELIZED_COST_RATES),
         value_fn=lambda obj: None,
     ),
     PowerInsightSensorDescription(
@@ -367,7 +362,6 @@ POWER_INSIGHT_COMBINED_LEDGER_SENSORS = (
         entities_fn=lambda obj: (
             obj.source_entities_price + obj.source_entities_power
         ),
-        exists_fn=lambda options: options.check(CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES),
         value_fn=lambda obj: None,
     ),
 )
@@ -408,7 +402,6 @@ POWER_INSIGHT_GRID_ADAPTER_SENSORS = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
         entities_fn=lambda obj: obj.source_entities_price + obj.source_entities_power,
-        exists_fn=lambda options: options.check(CONF_CALCULATE_COST_RATES),
         value_fn=lambda obj: obj.grid_adapters_coe_rate,
     ),
     PowerInsightSensorDescription(
@@ -499,7 +492,6 @@ POWER_INSIGHT_GRID_ADAPTER_INTEGRATION_SENSORS = (
         device_class=SensorDeviceClass.MONETARY,
         suggested_display_precision=2,
         entities_fn=lambda obj: obj.source_entities_price + obj.source_entities_power,
-        exists_fn=lambda options: options.check(CONF_ACCUMULATE_COST_RATES),
         integration_value_fn=lambda obj: obj.grid_adapters_coe_rate,
     ),
     PowerInsightIntegrationSensorDescription(
@@ -1024,21 +1016,26 @@ POWER_INSIGHT_CONS_ADAPTER_INTEGRATION_SENSORS: tuple[
 
 
 class OptionsWrapper:
-    """Wrapper around the raw options dict providing a unified check interface."""
+    """Scope-aware view over the per-scope options dict.
+
+    Options are stored as ``entry.options["scopes"][scope] = [enabled leaf
+    keys]`` plus the global ``debug_power_entities`` flag. ``check(key, scope)``
+    resolves whether a leaf option is enabled for a given scope.
+    """
 
     def __init__(self, options: dict) -> None:
         """Initialise from the raw options dict."""
         self._options = options
-        self._selected: set[str] = set()
-        for key, value in options.items():
-            if isinstance(value, list):
-                self._selected.update(value)
+        scopes = options.get("scopes", {})
+        self._by_scope: dict[str, set[str]] = {
+            scope: set(leaves) for scope, leaves in scopes.items()
+        }
 
-    def check(self, key: str) -> bool:
-        """Return True if the key is enabled, either as a boolean or a selected list item."""
-        if key in self._selected:
-            return True
-        return bool(self._options.get(key, False))
+    def check(self, key: str, scope: str = SCOPE_COMBINED) -> bool:
+        """Return True if *key* is enabled for *scope*."""
+        if key == CONF_ENABLE_DEBUG_ENTITIES:
+            return bool(self._options.get(key, False))
+        return key in self._by_scope.get(scope, set())
 
 
 # ---------------------------------------------------------------------------
@@ -1048,44 +1045,73 @@ class OptionsWrapper:
 # Maps a sensor description ``key`` to the integration option that controls
 # whether it is created. A sensor whose key is absent here is not option-gated
 # (it is still subject to its adapter-capability ``exists_fn``). This is the
-# single source of truth for which option enables which sensor, so toggling an
-# option in the options flow takes effect for *every* matching sensor — hub,
-# grid and per-adapter alike. Dynamic per-source sensors (charging shares,
-# consumer source ratios) are gated inline in ``async_setup_entry`` instead,
-# since their keys are built at runtime.
+# single source of truth for which option enables which sensor; each setup loop
+# evaluates it against the scope it is building (combined / grid / pv_system /
+# battery / consumer). Dynamic per-source sensors (charging shares, consumer
+# source ratios) are gated inline in ``async_setup_entry``, since their keys are
+# built at runtime.
 _SENSOR_OPTION_GATE: dict[str, str] = {
-    # --- Power-share (percentage) sensors ---
-    "combined_export_ratio": CONF_ENABLE_POWER_SHARES,
-    "combined_self_consumption_ratio": CONF_ENABLE_POWER_SHARES,
-    "combined_charging_ratio": CONF_ENABLE_POWER_SHARES,
-    "combined_standby_ratio": CONF_ENABLE_POWER_SHARES,
-    "consumption_ratio": CONF_ENABLE_POWER_SHARES,   # grid
-    "consumption_share": CONF_ENABLE_POWER_SHARES,   # grid
-    "export_ratio": CONF_ENABLE_POWER_SHARES,        # pv / storage
-    "export_share": CONF_ENABLE_POWER_SHARES,        # pv / storage
-    "self_consumption_ratio": CONF_ENABLE_POWER_SHARES,
-    "self_consumption_share": CONF_ENABLE_POWER_SHARES,
-    # --- Per-adapter instantaneous rate sensors ---
-    "export_compensation_rate": CONF_CALCULATE_COST_RATES,
+    # --- Diagnostics ---
+    "available_power": CONF_ENABLE_DEBUG_ENTITIES,
+    # --- Power distribution (W) ---
+    "import_power": CONF_ENABLE_DISTRIBUTION_POWER,                # grid
+    "export_power": CONF_ENABLE_DISTRIBUTION_POWER,                # grid / pv / storage
+    "self_consumption_power": CONF_ENABLE_DISTRIBUTION_POWER,      # pv / storage
+    "combined_self_consumption_power": CONF_ENABLE_DISTRIBUTION_POWER,
+    "combined_charging_power": CONF_ENABLE_DISTRIBUTION_POWER,
+    "combined_standby_power": CONF_ENABLE_DISTRIBUTION_POWER,
+    # --- Power distribution ratios ---
+    "combined_export_ratio": CONF_ENABLE_DISTRIBUTION_RATIOS,
+    "combined_self_consumption_ratio": CONF_ENABLE_DISTRIBUTION_RATIOS,
+    "combined_charging_ratio": CONF_ENABLE_DISTRIBUTION_RATIOS,
+    "combined_standby_ratio": CONF_ENABLE_DISTRIBUTION_RATIOS,
+    "consumption_ratio": CONF_ENABLE_DISTRIBUTION_RATIOS,          # grid
+    "export_ratio": CONF_ENABLE_DISTRIBUTION_RATIOS,              # pv / storage
+    "self_consumption_ratio": CONF_ENABLE_DISTRIBUTION_RATIOS,
+    # --- Power distribution shares ---
+    "consumption_share": CONF_ENABLE_DISTRIBUTION_SHARES,         # grid
+    "export_share": CONF_ENABLE_DISTRIBUTION_SHARES,             # pv / storage
+    "self_consumption_share": CONF_ENABLE_DISTRIBUTION_SHARES,
+    # --- Export compensation ---
+    "export_compensation_rate": CONF_ENABLE_EXPORT_COMPENSATION_RATE,
+    "total_export_compensation": CONF_ACCUMULATE_EXPORT_COMPENSATION,
+    # --- Cost rates ---
+    "cost_rate": CONF_CALCULATE_COST_RATES,                       # grid
     "operating_cost_rate": CONF_CALCULATE_COST_RATES,
+    "combined_cost_rate": CONF_CALCULATE_COST_RATES,
+    "combined_operating_cost_rate": CONF_CALCULATE_COST_RATES,
+    # --- Levelized cost rates ---
     "levelized_operating_cost_rate": CONF_CALCULATE_LEVELIZED_COST_RATES,
+    "combined_levelized_cost_rate": CONF_CALCULATE_LEVELIZED_COST_RATES,
+    "combined_levelized_operating_cost_rate": CONF_CALCULATE_LEVELIZED_COST_RATES,
+    # --- Cost savings rates ---
     "self_consumption_cost_savings_rate": CONF_CALCULATE_COST_SAVING_RATES,
     "cost_savings_rate": CONF_CALCULATE_COST_SAVING_RATES,
+    "combined_self_consumption_cost_savings_rate": CONF_CALCULATE_COST_SAVING_RATES,
+    "combined_cost_savings_rate": CONF_CALCULATE_COST_SAVING_RATES,
+    # --- Levelized cost savings rates ---
     "levelized_cost_savings_rate": CONF_CALCULATE_LEVELIZED_COST_SAVING_RATES,
-    # --- Per-adapter accumulated total sensors ---
-    "total_export_compensation": CONF_ACCUMULATE_COST_RATES,
+    "combined_levelized_cost_savings_rate": CONF_CALCULATE_LEVELIZED_COST_SAVING_RATES,
+    # --- Accumulated costs ---
+    "total_cost": CONF_ACCUMULATE_COST_RATES,                     # grid
     "total_operating_costs": CONF_ACCUMULATE_COST_RATES,
+    "combined_total_operating_costs": CONF_ACCUMULATE_COST_RATES,
     "total_levelized_operating_costs": CONF_ACCUMULATE_LEVELIZED_COST_RATES,
+    "combined_total_levelized_operating_costs": CONF_ACCUMULATE_LEVELIZED_COST_RATES,
+    # --- Accumulated cost savings ---
     "total_self_consumption_cost_savings": CONF_ACCUMULATE_COST_SAVING_RATES,
     "total_cost_savings": CONF_ACCUMULATE_COST_SAVING_RATES,
+    "combined_total_self_consumption_cost_savings": CONF_ACCUMULATE_COST_SAVING_RATES,
+    "combined_total_cost_savings": CONF_ACCUMULATE_COST_SAVING_RATES,
     "total_levelized_cost_savings": CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES,
+    "combined_total_levelized_cost_savings": CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES,
 }
 
 
-def _option_gated_out(description, options: OptionsWrapper) -> bool:
-    """Return True if *description* is gated off by the current options."""
+def _option_gated_out(description, options: OptionsWrapper, scope: str) -> bool:
+    """Return True if *description* is gated off for *scope* by the options."""
     gate = _SENSOR_OPTION_GATE.get(description.key)
-    return gate is not None and not options.check(gate)
+    return gate is not None and not options.check(gate, scope)
 
 
 @callback
@@ -1173,7 +1199,7 @@ async def async_setup_entry(
     for description in POWER_INSIGHT_SENSORS:
         if not description.exists_fn(options_wrapped):
             continue
-        if _option_gated_out(description, options_wrapped):
+        if _option_gated_out(description, options_wrapped, SCOPE_COMBINED):
             continue
         entities.append(PowerInsightSensor(
             description=description,
@@ -1185,7 +1211,7 @@ async def async_setup_entry(
     for description in POWER_INSIGHT_INTEGRATION_SENSORS:
         if not description.exists_fn(options_wrapped):
             continue
-        if _option_gated_out(description, options_wrapped):
+        if _option_gated_out(description, options_wrapped, SCOPE_COMBINED):
             continue
         entities.append(PowerInsightIntegrationSensor(
             description=description,
@@ -1199,7 +1225,7 @@ async def async_setup_entry(
     for description in POWER_INSIGHT_COMBINED_LEDGER_SENSORS:
         if not description.exists_fn(options_wrapped):
             continue
-        if _option_gated_out(description, options_wrapped):
+        if _option_gated_out(description, options_wrapped, SCOPE_COMBINED):
             continue
         entities.append(PowerInsightCombinedLedgerSensor(
             description=description,
@@ -1216,7 +1242,7 @@ async def async_setup_entry(
     for description in POWER_INSIGHT_GRID_ADAPTER_SENSORS:
         if not description.exists_fn(options_wrapped):
             continue
-        if _option_gated_out(description, options_wrapped):
+        if _option_gated_out(description, options_wrapped, "grid"):
             continue
         entities.append(PowerInsightAdapterSensor(
             description=description,
@@ -1229,7 +1255,7 @@ async def async_setup_entry(
     for description in POWER_INSIGHT_GRID_ADAPTER_INTEGRATION_SENSORS:
         if not description.exists_fn(options_wrapped):
             continue
-        if _option_gated_out(description, options_wrapped):
+        if _option_gated_out(description, options_wrapped, "grid"):
             continue
         entities.append(PowerInsightAdapterIntegrationSensor(
             description=description,
@@ -1247,7 +1273,7 @@ async def async_setup_entry(
         for description in POWER_INSIGHT_PV_ADAPTER_SENSORS:
             if not description.exists_fn(adapter):
                 continue
-            if _option_gated_out(description, options_wrapped):
+            if _option_gated_out(description, options_wrapped, "pv_system"):
                 continue
             entities.append(PowerInsightAdapterSensor(
                 description=description,
@@ -1260,7 +1286,7 @@ async def async_setup_entry(
         for description in POWER_INSIGHT_PV_ADAPTER_INTEGRATION_SENSORS:
             if not description.exists_fn(adapter):
                 continue
-            if _option_gated_out(description, options_wrapped):
+            if _option_gated_out(description, options_wrapped, "pv_system"):
                 continue
             entities.append(PowerInsightAdapterIntegrationSensor(
                 description=description,
@@ -1279,7 +1305,7 @@ async def async_setup_entry(
         for description in POWER_INSIGHT_STORAGE_ADAPTER_SENSORS:
             if not description.exists_fn(adapter):
                 continue
-            if _option_gated_out(description, options_wrapped):
+            if _option_gated_out(description, options_wrapped, "battery"):
                 continue
             entities.append(PowerInsightAdapterSensor(
                 description=description,
@@ -1292,7 +1318,7 @@ async def async_setup_entry(
         for description in POWER_INSIGHT_STORAGE_ADAPTER_INTEGRATION_SENSORS:
             if not description.exists_fn(adapter):
                 continue
-            if _option_gated_out(description, options_wrapped):
+            if _option_gated_out(description, options_wrapped, "battery"):
                 continue
             entities.append(PowerInsightAdapterIntegrationSensor(
                 description=description,
@@ -1307,7 +1333,7 @@ async def async_setup_entry(
         # the user did not select under "Charge From" gets no sensor (e.g. no
         # "Charging share from Grid" when the battery cannot charge from grid).
         # These are power-share sensors, so gate them on that option too.
-        if options_wrapped.check(CONF_ENABLE_POWER_SHARES):
+        if options_wrapped.check(CONF_ENABLE_CHARGING_SOURCE_SHARES, "battery"):
             for source_adapter in power_insight.gross_power_adapters:
                 if source_adapter.uid not in adapter.charge_from_adapters:
                     continue
@@ -1341,7 +1367,7 @@ async def async_setup_entry(
         for description in POWER_INSIGHT_CONS_ADAPTER_SENSORS:
             if not description.exists_fn(adapter):
                 continue
-            if _option_gated_out(description, options_wrapped):
+            if _option_gated_out(description, options_wrapped, "consumer"):
                 continue
             entities.append(PowerInsightAdapterSensor(
                 description=description,
@@ -1354,7 +1380,7 @@ async def async_setup_entry(
         for description in POWER_INSIGHT_CONS_ADAPTER_INTEGRATION_SENSORS:
             if not description.exists_fn(adapter):
                 continue
-            if _option_gated_out(description, options_wrapped):
+            if _option_gated_out(description, options_wrapped, "consumer"):
                 continue
             entities.append(PowerInsightAdapterIntegrationSensor(
                 description=description,
@@ -1366,7 +1392,7 @@ async def async_setup_entry(
 
         # Dynamic consumption source share sensors — one per power-providing
         # adapter. These are power-share sensors, so gate them on that option.
-        if options_wrapped.check(CONF_ENABLE_POWER_SHARES):
+        if options_wrapped.check(CONF_ENABLE_POWER_SOURCE_SHARES, "consumer"):
             for source_adapter in power_insight.gross_power_adapters:
                 name = source_adapter.verbose_name
                 dynamic_description = PowerInsightSensorDescription(

--- a/custom_components/power_insight/sensor.py
+++ b/custom_components/power_insight/sensor.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers import entity_registry as er
@@ -33,6 +33,7 @@ from . import MyConfigEntry
 from .const import (
     DOMAIN,
     CONF_ENABLE_DEBUG_ENTITIES,
+    CONF_ENABLE_POWER_SHARES,
     CONF_CALCULATE_COST_RATES,
     CONF_CALCULATE_LEVELIZED_COST_RATES,
     CONF_CALCULATE_COST_SAVING_RATES,
@@ -1024,6 +1025,81 @@ class OptionsWrapper:
         return bool(self._options.get(key, False))
 
 
+# ---------------------------------------------------------------------------
+# Option gating
+# ---------------------------------------------------------------------------
+#
+# Maps a sensor description ``key`` to the integration option that controls
+# whether it is created. A sensor whose key is absent here is not option-gated
+# (it is still subject to its adapter-capability ``exists_fn``). This is the
+# single source of truth for which option enables which sensor, so toggling an
+# option in the options flow takes effect for *every* matching sensor — hub,
+# grid and per-adapter alike. Dynamic per-source sensors (charging shares,
+# consumer source ratios) are gated inline in ``async_setup_entry`` instead,
+# since their keys are built at runtime.
+_SENSOR_OPTION_GATE: dict[str, str] = {
+    # --- Power-share (percentage) sensors ---
+    "combined_export_ratio": CONF_ENABLE_POWER_SHARES,
+    "combined_self_consumption_ratio": CONF_ENABLE_POWER_SHARES,
+    "combined_charging_ratio": CONF_ENABLE_POWER_SHARES,
+    "combined_standby_ratio": CONF_ENABLE_POWER_SHARES,
+    "consumption_ratio": CONF_ENABLE_POWER_SHARES,   # grid
+    "consumption_share": CONF_ENABLE_POWER_SHARES,   # grid
+    "export_ratio": CONF_ENABLE_POWER_SHARES,        # pv / storage
+    "export_share": CONF_ENABLE_POWER_SHARES,        # pv / storage
+    "self_consumption_ratio": CONF_ENABLE_POWER_SHARES,
+    "self_consumption_share": CONF_ENABLE_POWER_SHARES,
+    # --- Per-adapter instantaneous rate sensors ---
+    "export_compensation_rate": CONF_CALCULATE_COST_RATES,
+    "operating_cost_rate": CONF_CALCULATE_COST_RATES,
+    "levelized_operating_cost_rate": CONF_CALCULATE_LEVELIZED_COST_RATES,
+    "self_consumption_cost_savings_rate": CONF_CALCULATE_COST_SAVING_RATES,
+    "cost_savings_rate": CONF_CALCULATE_COST_SAVING_RATES,
+    "levelized_cost_savings_rate": CONF_CALCULATE_LEVELIZED_COST_SAVING_RATES,
+    # --- Per-adapter accumulated total sensors ---
+    "total_export_compensation": CONF_ACCUMULATE_COST_RATES,
+    "total_operating_costs": CONF_ACCUMULATE_COST_RATES,
+    "total_levelized_operating_costs": CONF_ACCUMULATE_LEVELIZED_COST_RATES,
+    "total_self_consumption_cost_savings": CONF_ACCUMULATE_COST_SAVING_RATES,
+    "total_cost_savings": CONF_ACCUMULATE_COST_SAVING_RATES,
+    "total_levelized_cost_savings": CONF_ACCUMULATE_LEVELIZED_COST_SAVING_RATES,
+}
+
+
+def _option_gated_out(description, options: OptionsWrapper) -> bool:
+    """Return True if *description* is gated off by the current options."""
+    gate = _SENSOR_OPTION_GATE.get(description.key)
+    return gate is not None and not options.check(gate)
+
+
+@callback
+def _sync_entity_enabled_state(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    wanted_unique_ids: set[str],
+) -> None:
+    """Disable entities whose option is off; re-enable them when it is back on.
+
+    Rather than deleting the entities of a disabled sensor group (which would
+    drop their recorded history), we mark them disabled in the entity registry.
+    They are hidden and stop updating, but keep their history and are restored
+    the moment the option is re-enabled. Entities the user disabled themselves
+    (``disabled_by == USER``) are never touched.
+    """
+    ent_reg = er.async_get(hass)
+    for ent in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
+        if ent.platform != DOMAIN or ent.domain != "sensor":
+            continue
+        if ent.unique_id in wanted_unique_ids:
+            if ent.disabled_by is er.RegistryEntryDisabler.INTEGRATION:
+                ent_reg.async_update_entity(ent.entity_id, disabled_by=None)
+        elif ent.disabled_by is None:
+            ent_reg.async_update_entity(
+                ent.entity_id,
+                disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+            )
+
+
 def _resolve_currency_unit(unit: str | None, hass: HomeAssistant | None) -> str | None:
     """Replace the ``EUR`` placeholder in a unit with the configured currency.
 
@@ -1067,11 +1143,21 @@ async def async_setup_entry(
     if power_insight.grid_adapter is None:
         return
     options_wrapped = OptionsWrapper(entry.options)
+    # Unique IDs of every sensor we create this run, used afterwards to disable
+    # (and later re-enable) entities whose controlling option has been toggled.
+    created_unique_ids: set[str] = set()
+
+    def _add(entities: list, **kwargs) -> None:
+        """Register a batch of entities and record their unique IDs."""
+        created_unique_ids.update(ent.unique_id for ent in entities)
+        async_add_entities(entities, **kwargs)
 
     # --- Hub-level sensors ---
     entities: list = []
     for description in POWER_INSIGHT_SENSORS:
         if not description.exists_fn(options_wrapped):
+            continue
+        if _option_gated_out(description, options_wrapped):
             continue
         entities.append(PowerInsightSensor(
             description=description,
@@ -1082,6 +1168,8 @@ async def async_setup_entry(
 
     for description in POWER_INSIGHT_INTEGRATION_SENSORS:
         if not description.exists_fn(options_wrapped):
+            continue
+        if _option_gated_out(description, options_wrapped):
             continue
         entities.append(PowerInsightIntegrationSensor(
             description=description,
@@ -1095,6 +1183,8 @@ async def async_setup_entry(
     for description in POWER_INSIGHT_COMBINED_LEDGER_SENSORS:
         if not description.exists_fn(options_wrapped):
             continue
+        if _option_gated_out(description, options_wrapped):
+            continue
         entities.append(PowerInsightCombinedLedgerSensor(
             description=description,
             config_entry=entry,
@@ -1102,13 +1192,15 @@ async def async_setup_entry(
             power_insight=power_insight,
         ))
 
-    async_add_entities(entities)
+    _add(entities)
 
     # --- Grid adapter sensors ---
     grid_adapter = power_insight.grid_adapter
     entities = []
     for description in POWER_INSIGHT_GRID_ADAPTER_SENSORS:
         if not description.exists_fn(options_wrapped):
+            continue
+        if _option_gated_out(description, options_wrapped):
             continue
         entities.append(PowerInsightAdapterSensor(
             description=description,
@@ -1121,6 +1213,8 @@ async def async_setup_entry(
     for description in POWER_INSIGHT_GRID_ADAPTER_INTEGRATION_SENSORS:
         if not description.exists_fn(options_wrapped):
             continue
+        if _option_gated_out(description, options_wrapped):
+            continue
         entities.append(PowerInsightAdapterIntegrationSensor(
             description=description,
             config_entry=entry,
@@ -1129,13 +1223,15 @@ async def async_setup_entry(
             device_adapter=grid_adapter,
         ))
 
-    async_add_entities(entities, config_subentry_id=grid_adapter.uid)
+    _add(entities, config_subentry_id=grid_adapter.uid)
 
     # --- PV adapter sensors ---
     for adapter in power_insight.pv_system_adapters:
         entities = []
         for description in POWER_INSIGHT_PV_ADAPTER_SENSORS:
             if not description.exists_fn(adapter):
+                continue
+            if _option_gated_out(description, options_wrapped):
                 continue
             entities.append(PowerInsightAdapterSensor(
                 description=description,
@@ -1148,6 +1244,8 @@ async def async_setup_entry(
         for description in POWER_INSIGHT_PV_ADAPTER_INTEGRATION_SENSORS:
             if not description.exists_fn(adapter):
                 continue
+            if _option_gated_out(description, options_wrapped):
+                continue
             entities.append(PowerInsightAdapterIntegrationSensor(
                 description=description,
                 config_entry=entry,
@@ -1156,7 +1254,7 @@ async def async_setup_entry(
                 device_adapter=adapter,
             ))
 
-        async_add_entities(entities, config_subentry_id=adapter.uid)
+        _add(entities, config_subentry_id=adapter.uid)
 
     # --- Battery adapter sensors ---
     for adapter in power_insight.storage_adapters:
@@ -1164,6 +1262,8 @@ async def async_setup_entry(
 
         for description in POWER_INSIGHT_STORAGE_ADAPTER_SENSORS:
             if not description.exists_fn(adapter):
+                continue
+            if _option_gated_out(description, options_wrapped):
                 continue
             entities.append(PowerInsightAdapterSensor(
                 description=description,
@@ -1175,6 +1275,8 @@ async def async_setup_entry(
 
         for description in POWER_INSIGHT_STORAGE_ADAPTER_INTEGRATION_SENSORS:
             if not description.exists_fn(adapter):
+                continue
+            if _option_gated_out(description, options_wrapped):
                 continue
             entities.append(PowerInsightAdapterIntegrationSensor(
                 description=description,
@@ -1188,31 +1290,33 @@ async def async_setup_entry(
         # adapter the battery is actually configured to charge from. A source
         # the user did not select under "Charge From" gets no sensor (e.g. no
         # "Charging share from Grid" when the battery cannot charge from grid).
-        for source_adapter in power_insight.gross_power_adapters:
-            if source_adapter.uid not in adapter.charge_from_adapters:
-                continue
-            name = source_adapter.verbose_name
-            dynamic_description = PowerInsightSensorDescription(
-                key=f"charging_share_from_{name}",
-                name=f"Charging share from {name}",
-                icon="mdi:percent",
-                native_unit_of_measurement=PERCENTAGE,
-                state_class=SensorStateClass.MEASUREMENT,
-                suggested_display_precision=0,
-                entities_fn=lambda obj: obj.source_entities_power,
-                value_fn=lambda obj: obj.storage_adapters_charging_source_shares,
-                transform_fn=lambda val: val * 100,
-            )
-            entities.append(PowerInsightDynamicAdapterSensor(
-                description=dynamic_description,
-                config_entry=entry,
-                source_entities=dynamic_description.entities_fn(power_insight),
-                power_insight=power_insight,
-                device_adapter=adapter,
-                dynamic_adapter=source_adapter,
-            ))
+        # These are power-share sensors, so gate them on that option too.
+        if options_wrapped.check(CONF_ENABLE_POWER_SHARES):
+            for source_adapter in power_insight.gross_power_adapters:
+                if source_adapter.uid not in adapter.charge_from_adapters:
+                    continue
+                name = source_adapter.verbose_name
+                dynamic_description = PowerInsightSensorDescription(
+                    key=f"charging_share_from_{name}",
+                    name=f"Charging share from {name}",
+                    icon="mdi:percent",
+                    native_unit_of_measurement=PERCENTAGE,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    suggested_display_precision=0,
+                    entities_fn=lambda obj: obj.source_entities_power,
+                    value_fn=lambda obj: obj.storage_adapters_charging_source_shares,
+                    transform_fn=lambda val: val * 100,
+                )
+                entities.append(PowerInsightDynamicAdapterSensor(
+                    description=dynamic_description,
+                    config_entry=entry,
+                    source_entities=dynamic_description.entities_fn(power_insight),
+                    power_insight=power_insight,
+                    device_adapter=adapter,
+                    dynamic_adapter=source_adapter,
+                ))
 
-        async_add_entities(entities, config_subentry_id=adapter.uid)
+        _add(entities, config_subentry_id=adapter.uid)
 
     # --- Consumer adapter sensors ---
     for adapter in power_insight.consumer_adapters:
@@ -1220,6 +1324,8 @@ async def async_setup_entry(
 
         for description in POWER_INSIGHT_CONS_ADAPTER_SENSORS:
             if not description.exists_fn(adapter):
+                continue
+            if _option_gated_out(description, options_wrapped):
                 continue
             entities.append(PowerInsightAdapterSensor(
                 description=description,
@@ -1232,6 +1338,8 @@ async def async_setup_entry(
         for description in POWER_INSIGHT_CONS_ADAPTER_INTEGRATION_SENSORS:
             if not description.exists_fn(adapter):
                 continue
+            if _option_gated_out(description, options_wrapped):
+                continue
             entities.append(PowerInsightAdapterIntegrationSensor(
                 description=description,
                 config_entry=entry,
@@ -1240,30 +1348,36 @@ async def async_setup_entry(
                 device_adapter=adapter,
             ))
 
-        # Dynamic consumption source share sensors — one per power-providing adapter
-        for source_adapter in power_insight.gross_power_adapters:
-            name = source_adapter.verbose_name
-            dynamic_description = PowerInsightSensorDescription(
-                key=f"{name}_ratio",
-                name=f"{name} ratio",
-                icon="mdi:percent",
-                native_unit_of_measurement=PERCENTAGE,
-                state_class=SensorStateClass.MEASUREMENT,
-                suggested_display_precision=0,
-                entities_fn=lambda obj: obj.source_entities_power,
-                value_fn=lambda obj: obj.cons_adapters_source_shares,
-                transform_fn=lambda val: val * 100,
-            )
-            entities.append(PowerInsightDynamicAdapterSensor(
-                description=dynamic_description,
-                config_entry=entry,
-                source_entities=dynamic_description.entities_fn(power_insight),
-                power_insight=power_insight,
-                device_adapter=adapter,
-                dynamic_adapter=source_adapter,
-            ))
+        # Dynamic consumption source share sensors — one per power-providing
+        # adapter. These are power-share sensors, so gate them on that option.
+        if options_wrapped.check(CONF_ENABLE_POWER_SHARES):
+            for source_adapter in power_insight.gross_power_adapters:
+                name = source_adapter.verbose_name
+                dynamic_description = PowerInsightSensorDescription(
+                    key=f"{name}_ratio",
+                    name=f"{name} ratio",
+                    icon="mdi:percent",
+                    native_unit_of_measurement=PERCENTAGE,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    suggested_display_precision=0,
+                    entities_fn=lambda obj: obj.source_entities_power,
+                    value_fn=lambda obj: obj.cons_adapters_source_shares,
+                    transform_fn=lambda val: val * 100,
+                )
+                entities.append(PowerInsightDynamicAdapterSensor(
+                    description=dynamic_description,
+                    config_entry=entry,
+                    source_entities=dynamic_description.entities_fn(power_insight),
+                    power_insight=power_insight,
+                    device_adapter=adapter,
+                    dynamic_adapter=source_adapter,
+                ))
 
-        async_add_entities(entities, config_subentry_id=adapter.uid)
+        _add(entities, config_subentry_id=adapter.uid)
+
+    # Disable entities whose controlling option is now off (keeping their
+    # history), and re-enable any we previously disabled that are wanted again.
+    _sync_entity_enabled_state(hass, entry, created_unique_ids)
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/power_insight/sensor.py
+++ b/custom_components/power_insight/sensor.py
@@ -1184,8 +1184,13 @@ async def async_setup_entry(
                 device_adapter=adapter,
             ))
 
-        # Dynamic charging source share sensors — one per power-providing adapter
+        # Dynamic charging source share sensors — one per power-providing
+        # adapter the battery is actually configured to charge from. A source
+        # the user did not select under "Charge From" gets no sensor (e.g. no
+        # "Charging share from Grid" when the battery cannot charge from grid).
         for source_adapter in power_insight.gross_power_adapters:
+            if source_adapter.uid not in adapter.charge_from_adapters:
+                continue
             name = source_adapter.verbose_name
             dynamic_description = PowerInsightSensorDescription(
                 key=f"charging_share_from_{name}",

--- a/custom_components/power_insight/translations/en.json
+++ b/custom_components/power_insight/translations/en.json
@@ -12,8 +12,8 @@
         },
         "data_description": {
           "name": "A name for this energy mix configuration.",
-          "calculate_instantaneous_rates": "Select which instantaneous rate sensors to create, e.g. cost rate (per hour) or CO\u2082 intensity rate.",
-          "calculate_instantaneous_saving_rates": "Select which instantaneous saving rate sensors to create, e.g. cost savings rate (per hour). Requires a price or CO\u2082 entity on the grid adapter depending on your selection.",
+          "calculate_instantaneous_rates": "Select which instantaneous rate sensors to create, e.g. cost rate (per hour) or CO₂ intensity rate.",
+          "calculate_instantaneous_saving_rates": "Select which instantaneous saving rate sensors to create, e.g. cost savings rate (per hour). Requires a price or CO₂ entity on the grid adapter depending on your selection.",
           "calculate_accumulated_entities": "Select which accumulated total sensors to create, e.g. cost savings or export compensation."
         }
       }
@@ -30,25 +30,135 @@
     "step": {
       "init": {
         "title": "Options",
-        "description": "Adjust calculation settings and enable or disable groups of sensor entities.\nChanges are applied automatically — the integration reloads itself, so no Home Assistant restart is needed. Disabled sensors are hidden but keep their history and reappear when re-enabled.",
+        "description": "Choose a section to configure which sensors to create. Each device type shows only the options it supports.\nChanges apply automatically — the integration reloads itself, so no Home Assistant restart is needed. Disabled sensors are hidden but keep their history and reappear when re-enabled.",
+        "menu_options": {
+          "combined": "Whole-home (combined)",
+          "grid": "Grid",
+          "pv_system": "PV systems",
+          "battery": "Batteries",
+          "consumer": "Consumers",
+          "diagnostics": "Diagnostics",
+          "save": "Save and apply"
+        }
+      },
+      "combined": {
+        "title": "Whole-home sensors",
+        "description": "Sensors that aggregate your whole energy mix.",
         "data": {
-          "calculate_instantaneous_rates": "Instantaneous rate sensors",
-          "calculate_instantaneous_saving_rates": "Instantaneous saving rate sensors",
-          "calculate_accumulated_entities": "Accumulated total sensors",
-          "enable_power_shares": "Power share sensors",
+          "distribution_power": "Power distribution (W)",
+          "cost_rates": "Cost rates (per hour)",
+          "cost_savings_rates": "Cost savings rates (per hour)",
+          "accumulated_costs": "Accumulated costs",
+          "accumulated_cost_savings": "Accumulated cost savings",
+          "distribution_ratios": "Power distribution ratios"
+        },
+        "data_description": {
+          "distribution_power": "Watt power-split sensors (import/export, self-consumption, charging, standby).",
+          "cost_rates": "Operating cost rate, and optionally its levelized variant.",
+          "cost_savings_rates": "Self-consumption cost savings rate, and optionally its levelized variant.",
+          "accumulated_costs": "Running totals of operating cost.",
+          "accumulated_cost_savings": "Running totals of cost savings.",
+          "distribution_ratios": "Percentage of a device's own power that is exported, self-consumed, charging or standby."
+        }
+      },
+      "grid": {
+        "title": "Grid sensors",
+        "description": "Import/export power, cost and export compensation at your grid connection.",
+        "data": {
+          "distribution_power": "Power distribution (W)",
+          "cost_rates": "Cost rates (per hour)",
+          "accumulated_costs": "Accumulated costs",
+          "export_compensation": "Export compensation",
+          "distribution_ratios": "Power distribution ratios",
+          "distribution_shares": "Power distribution shares"
+        },
+        "data_description": {
+          "distribution_power": "Watt power-split sensors (import/export, self-consumption, charging, standby).",
+          "cost_rates": "Operating cost rate, and optionally its levelized variant.",
+          "accumulated_costs": "Running totals of operating cost.",
+          "export_compensation": "Compensation for energy fed to the grid: the rate and/or its running total.",
+          "distribution_ratios": "Percentage of a device's own power that is exported, self-consumed, charging or standby.",
+          "distribution_shares": "A device's share of the combined export / self-consumption."
+        }
+      },
+      "pv_system": {
+        "title": "PV system sensors",
+        "description": "Applies to all PV system devices.",
+        "data": {
+          "distribution_power": "Power distribution (W)",
+          "cost_rates": "Cost rates (per hour)",
+          "cost_savings_rates": "Cost savings rates (per hour)",
+          "export_compensation": "Export compensation",
+          "accumulated_costs": "Accumulated costs",
+          "accumulated_cost_savings": "Accumulated cost savings",
+          "distribution_ratios": "Power distribution ratios",
+          "distribution_shares": "Power distribution shares"
+        },
+        "data_description": {
+          "distribution_power": "Watt power-split sensors (import/export, self-consumption, charging, standby).",
+          "cost_rates": "Operating cost rate, and optionally its levelized variant.",
+          "cost_savings_rates": "Self-consumption cost savings rate, and optionally its levelized variant.",
+          "export_compensation": "Compensation for energy fed to the grid: the rate and/or its running total.",
+          "accumulated_costs": "Running totals of operating cost.",
+          "accumulated_cost_savings": "Running totals of cost savings.",
+          "distribution_ratios": "Percentage of a device's own power that is exported, self-consumed, charging or standby.",
+          "distribution_shares": "A device's share of the combined export / self-consumption."
+        }
+      },
+      "battery": {
+        "title": "Battery sensors",
+        "description": "Applies to all battery devices.",
+        "data": {
+          "distribution_power": "Power distribution (W)",
+          "cost_rates": "Cost rates (per hour)",
+          "cost_savings_rates": "Cost savings rates (per hour)",
+          "export_compensation": "Export compensation",
+          "accumulated_costs": "Accumulated costs",
+          "accumulated_cost_savings": "Accumulated cost savings",
+          "distribution_ratios": "Power distribution ratios",
+          "distribution_shares": "Power distribution shares",
+          "charging_source_shares": "Charging source shares"
+        },
+        "data_description": {
+          "distribution_power": "Watt power-split sensors (import/export, self-consumption, charging, standby).",
+          "cost_rates": "Operating cost rate, and optionally its levelized variant.",
+          "cost_savings_rates": "Self-consumption cost savings rate, and optionally its levelized variant.",
+          "export_compensation": "Compensation for energy fed to the grid: the rate and/or its running total.",
+          "accumulated_costs": "Running totals of operating cost.",
+          "accumulated_cost_savings": "Running totals of cost savings.",
+          "distribution_ratios": "Percentage of a device's own power that is exported, self-consumed, charging or standby.",
+          "distribution_shares": "A device's share of the combined export / self-consumption.",
+          "charging_source_shares": "For each selected charge source, its share of the battery's charging."
+        }
+      },
+      "consumer": {
+        "title": "Consumer sensors",
+        "description": "Applies to all consumer devices.",
+        "data": {
+          "cost_rates": "Cost rates (per hour)",
+          "power_source_shares": "Power source shares"
+        },
+        "data_description": {
+          "cost_rates": "Operating cost rate, and optionally its levelized variant.",
+          "power_source_shares": "The share of this consumer's power coming from each source."
+        }
+      },
+      "diagnostics": {
+        "title": "Diagnostics",
+        "data": {
           "debug_power_entities": "Enable debug power entities"
         },
         "data_description": {
-          "calculate_instantaneous_rates": "Select which instantaneous rate sensors to create, e.g. cost rate (per hour) or CO\u2082 intensity rate.",
-          "calculate_instantaneous_saving_rates": "Select which instantaneous saving rate sensors to create, e.g. cost savings rate (per hour). Requires a price or CO\u2082 entity on the grid adapter depending on your selection.",
-          "calculate_accumulated_entities": "Select which accumulated total sensors to create, e.g. cost savings or export compensation.",
-          "enable_power_shares": "Create sensors for percentage shares such as export share and self-consumption share.",
           "debug_power_entities": "Expose power values used by the internal calculations as additional sensors. Useful for troubleshooting."
         }
+      },
+      "save": {
+        "title": "Save and apply",
+        "description": "Some devices are missing data required by your selection. You can save anyway and reconfigure them afterwards, or go back to adjust your choices."
       }
     },
     "error": {
-      "reconfigure_adapters_first": "One or more adapters are missing data required by the new settings.\nPlease reconfigure the following adapters first: {adapters_needing_reconfigure}."
+      "reconfigure_adapters_first": "These devices are missing data required by your selection: {adapters_needing_reconfigure}. Save to apply anyway, then reconfigure them."
     }
   },
   "config_subentries": {
@@ -76,28 +186,28 @@
             "power_entity": "Power Entity",
             "power_entity_inverted": "Invert Power Direction",
             "grid_electricity_price_entity": "Electricity Price Entity",
-            "co2_intensity_entity": "CO\u2082 Intensity Entity",
+            "co2_intensity_entity": "CO₂ Intensity Entity",
             "exports_power": "Exports Power to Grid",
             "export_compensation": "Export Compensation Rate",
             "battery_efficiency": "Round-Trip Efficiency",
             "charge_from_adapters": "Charge From",
             "lifetime_production": "Lifetime Production",
             "lifetime_cost": "Total Lifetime Cost",
-            "co2_footprint": "CO\u2082 Footprint"
+            "co2_footprint": "CO₂ Footprint"
           },
           "data_description": {
             "name": "A unique name for this device.",
             "power_entity": "Sensor reporting power in W, kW, or MW. For the grid: positive = import, negative = export.",
             "power_entity_inverted": "Enable if your sensor reports the power direction inverted.",
             "grid_electricity_price_entity": "Sensor or input number providing the current electricity price per kWh (in your Home Assistant currency). Required when cost calculations are enabled.",
-            "co2_intensity_entity": "Sensor providing the current grid CO\u2082 intensity in g/kWh. Required when CO\u2082 calculations are enabled.",
+            "co2_intensity_entity": "Sensor providing the current grid CO₂ intensity in g/kWh. Required when CO₂ calculations are enabled.",
             "exports_power": "Enable if this device can export excess power to the grid.",
             "export_compensation": "Rate received per kWh exported to the grid (in your configured currency per kWh). Required when cost savings calculation is enabled.",
             "battery_efficiency": "The round-trip efficiency of the battery in percent.",
             "charge_from_adapters": "Select which adapters (grid and/or PV systems) this battery is allowed to charge from.",
             "lifetime_production": "Total expected energy production over the device lifetime (kWh). Required when levelized calculation is enabled.",
             "lifetime_cost": "Total investment and installation cost over the device lifetime (in your configured currency). Required when levelized cost calculation is enabled.",
-            "co2_footprint": "Total CO\u2082 emissions from manufacturing and installation (kg). Required when levelized CO\u2082 calculation is enabled."
+            "co2_footprint": "Total CO₂ emissions from manufacturing and installation (kg). Required when levelized CO₂ calculation is enabled."
           }
         },
         "reconfigure": {
@@ -107,7 +217,7 @@
             "power_entity": "Power Entity",
             "power_entity_inverted": "Invert Power Direction",
             "grid_electricity_price_entity": "Electricity Price Entity",
-            "co2_intensity_entity": "CO\u2082 Intensity Entity",
+            "co2_intensity_entity": "CO₂ Intensity Entity",
             "charge_from_adapters": "Charge From",
             "lifetime_production": "Lifetime Production",
             "lifetime_cost": "Total Lifetime Cost"
@@ -116,7 +226,7 @@
             "power_entity": "Sensor reporting power in W, kW, or MW.",
             "power_entity_inverted": "Enable if your sensor reports the power direction inverted.",
             "grid_electricity_price_entity": "Sensor or input number providing the current electricity price per kWh (in your Home Assistant currency). Required when cost calculations are enabled.",
-            "co2_intensity_entity": "Sensor providing the current grid CO\u2082 intensity in g/kWh. Required when CO\u2082 calculations are enabled.",
+            "co2_intensity_entity": "Sensor providing the current grid CO₂ intensity in g/kWh. Required when CO₂ calculations are enabled.",
             "charge_from_adapters": "Select which adapters (grid and/or PV systems) this battery is allowed to charge from.",
             "lifetime_production": "Total expected energy production over the device lifetime (kWh). Updating this rescales the displayed levelized values.",
             "lifetime_cost": "Total investment and installation cost over the device lifetime (in your configured currency). Updating this rescales the displayed levelized values."

--- a/custom_components/power_insight/translations/en.json
+++ b/custom_components/power_insight/translations/en.json
@@ -30,7 +30,7 @@
     "step": {
       "init": {
         "title": "Options",
-        "description": "Adjust calculation settings and enable or disable groups of sensor entities.\nChanges take effect after reloading the integration.",
+        "description": "Adjust calculation settings and enable or disable groups of sensor entities.\nChanges are applied automatically — the integration reloads itself, so no Home Assistant restart is needed. Disabled sensors are hidden but keep their history and reappear when re-enabled.",
         "data": {
           "calculate_instantaneous_rates": "Instantaneous rate sensors",
           "calculate_instantaneous_saving_rates": "Instantaneous saving rate sensors",

--- a/docs/options-flow-redesign.md
+++ b/docs/options-flow-redesign.md
@@ -1,6 +1,21 @@
 # Options flow redesign — final spec
 
-Status: **approved design, not yet implemented**
+Status: **implemented** (step 1: grid import/export sensors; step 2: per-scope
+options flow, gating, migration).
+
+Refinements made during implementation (the code is the source of truth):
+- The single `enable_power_shares` toggle was split into the categories
+  **Power distribution (W)** (`enable_distribution_power`), **Power
+  distribution ratios** (`enable_distribution_ratios`), **Power distribution
+  shares** (`enable_distribution_shares`), **Charging source shares**
+  (`enable_charging_source_shares`, battery) and **Power source shares**
+  (`enable_power_source_shares`, consumer).
+- **Export compensation** became its own category
+  (`enable_export_compensation_rate`, `accumulate_export_compensation`), and the
+  accumulated category was split into **Accumulated costs** and **Accumulated
+  cost savings**.
+- The grid gained **Import power** alongside Export power.
+- The options flow is a **menu** with one step per scope (no defaults/inherit).
 
 This spec reorganises the integration's options so that *which sensors are
 created* is configured **per device type**, in human‑readable categories, from a

--- a/docs/options-flow-redesign.md
+++ b/docs/options-flow-redesign.md
@@ -1,0 +1,499 @@
+# Options flow redesign — final spec
+
+Status: **approved design, not yet implemented**
+
+This spec reorganises the integration's options so that *which sensors are
+created* is configured **per device type**, in human‑readable categories, from a
+single central options flow. It folds in the related decisions to move the grid
+import/export sensors onto the grid device and to keep one grid per config
+entry.
+
+It builds on the gating work already merged (`_SENSOR_OPTION_GATE` +
+`_sync_entity_enabled_state` in `sensor.py`): every sensor is gated by an option
+and toggling an option disables (keeps history) / re‑enables its entities. This
+redesign only changes *how options are grouped and stored* and *which option
+gates which sensor* — the gating/enable machinery is reused unchanged.
+
+---
+
+## 1. Goals
+
+- One central options flow, **sectioned by device type** (no per‑subentry flows,
+  no global "defaults/inherit" bucket).
+- Each section shows **only the categories that device type supports**, with
+  friendly names.
+- The grid device owns **both sides of the meter**: import (cost) and export
+  (compensation + power).
+- **One grid per config entry** — the correct domain model, not a limitation
+  (two grid connections → two config entries).
+- Pre‑release: **no history‑preserving migration** required; entities may be
+  recreated.
+
+---
+
+## 2. Scope model
+
+Six configurable scopes. A scope is shown in the flow only if it applies (the
+device type has at least one subentry; `combined`/`diagnostics` always shown).
+
+| Scope | Meaning |
+|---|---|
+| `combined` | Whole‑home aggregate (hub) sensors |
+| `grid` | The single grid connection (import + export) |
+| `pv_system` | Applies to all PV system devices |
+| `battery` | Applies to all battery devices |
+| `consumer` | Applies to all consumer devices |
+| `diagnostics` | Global troubleshooting toggles |
+
+"Per device type" means a choice applies to **all** instances of that type, not
+per instance.
+
+---
+
+## 3. Category taxonomy & option keys
+
+Categories are the user‑facing groupings; each maps to one or more leaf option
+keys (the values actually stored and checked).
+
+### Money categories
+
+| Category (label) | Leaf option key(s) | Choice labels |
+|---|---|---|
+| Cost rates (€/h) | `calculate_cost_rates`, `calculate_levelized_cost_rates` | Cost, Levelized cost |
+| Cost savings rates (€/h) | `calculate_cost_saving_rates`, `calculate_levelized_cost_saving_rates` | Cost savings, Levelized cost savings |
+| Export compensation | `enable_export_compensation_rate`, `accumulate_export_compensation` | Rate (€/h), Accumulated total (€) |
+| Accumulated costs (€) | `accumulate_cost_rates`, `accumulate_levelized_cost_rates` | Cost, Levelized cost |
+| Accumulated cost savings (€) | `accumulate_cost_saving_rates`, `accumulate_levelized_cost_saving_rates` | Cost savings, Levelized cost savings |
+
+### Power categories
+
+| Category (label) | Leaf option key | Notes |
+|---|---|---|
+| Power distribution (W) | `enable_distribution_power` | absolute watt split |
+| Power distribution ratios | `enable_distribution_ratios` | `*_ratio` % (own power split) |
+| Power distribution shares | `enable_distribution_shares` | `*_share` % (share of combined) |
+| Charging source shares | `enable_charging_source_shares` | battery only |
+| Power source shares | `enable_power_source_shares` | consumer only |
+
+### Diagnostics
+
+| Category (label) | Leaf option key |
+|---|---|
+| Enable debug power entities | `debug_power_entities` |
+
+### Key changes vs today
+
+- **Added:** `enable_export_compensation_rate`, `accumulate_export_compensation`,
+  `enable_distribution_power`, `enable_distribution_ratios`,
+  `enable_distribution_shares`, `enable_charging_source_shares`,
+  `enable_power_source_shares`.
+- **Removed:** `enable_power_shares` (split into the four power categories), and
+  the three *container* keys `calculate_instantaneous_rates`,
+  `calculate_instantaneous_saving_rates`, `calculate_accumulated_entities`
+  (the flow now groups leaf keys by category directly).
+- **Repurposed:** export compensation is pulled **out** of `calculate_cost_rates`
+  / `accumulate_cost_rates` into its own two keys, so "Cost rates" and
+  "Accumulated costs" now mean strictly operating cost.
+
+### Which categories each scope offers (`SCOPE_SUPPORTED_OPTIONS`)
+
+| Scope | Categories |
+|---|---|
+| combined | Cost rates · Cost savings rates · Accumulated costs · Accumulated cost savings · Power distribution (W) · Power distribution ratios |
+| grid | Cost rates (Cost only) · Accumulated costs (Cost only) · Export compensation · Power distribution (W) · Power distribution ratios · Power distribution shares |
+| pv_system | Cost rates · Cost savings rates · Export compensation · Accumulated costs · Accumulated cost savings · Power distribution (W) · Power distribution ratios · Power distribution shares |
+| battery | same as pv_system **+ Charging source shares** |
+| consumer | Cost rates · Power source shares |
+| diagnostics | Enable debug power entities |
+
+---
+
+## 4. Per‑scope sections (exact fields shown)
+
+### Whole‑home (combined)
+- Cost rates (€/h): `Cost`, `Levelized cost`
+- Cost savings rates (€/h): `Cost savings`, `Levelized cost savings`
+- Accumulated costs (€): `Cost`, `Levelized cost`
+- Accumulated cost savings (€): `Cost savings`, `Levelized cost savings`
+- Power distribution (W) *(toggle)* — self‑consumption / charging / standby power
+- Power distribution ratios *(toggle)* — export / self‑consumption / charging / standby ratio
+- *(electricity‑price sensors stay always‑on — core readings)*
+
+### Grid
+- Power distribution (W) *(toggle)* — **import power, export power**
+- Cost rates (€/h): `Cost`
+- Accumulated costs (€): `Cost`
+- Export compensation: `Rate (€/h)`, `Accumulated total (€)`
+- Power distribution ratios *(toggle)* — consumption ratio
+- Power distribution shares *(toggle)* — consumption share
+
+### PV systems
+- Power distribution (W) *(toggle)* — export power, self‑consumption power
+- Cost rates (€/h): `Cost`, `Levelized cost`
+- Cost savings rates (€/h): `Cost savings`, `Levelized cost savings`
+- Export compensation: `Rate (€/h)`, `Accumulated total (€)`
+- Accumulated costs (€): `Cost`, `Levelized cost`
+- Accumulated cost savings (€): `Cost savings`, `Levelized cost savings`
+- Power distribution ratios *(toggle)* — export ratio, self‑consumption ratio
+- Power distribution shares *(toggle)* — export share, self‑consumption share
+
+### Batteries
+- Same as PV systems, plus:
+- Charging source shares *(toggle)* — charging share from each selected source
+- *(Export compensation shown only when the battery exports)*
+
+### Consumers
+- Cost rates (€/h): `Cost`, `Levelized cost`
+- Power source shares *(toggle)* — per‑source `<source> ratio`
+
+### Diagnostics
+- Enable debug power entities *(toggle)* — global
+
+---
+
+## 5. Sensor → scope → category map
+
+Capability gates (`exports_power`, `lcoe is not None`) still apply **in addition**
+to the option gate.
+
+### Combined (hub device)
+| Sensor key | Option key |
+|---|---|
+| combined_self_consumption_power | enable_distribution_power |
+| combined_charging_power | enable_distribution_power |
+| combined_standby_power | enable_distribution_power |
+| combined_export_ratio | enable_distribution_ratios |
+| combined_self_consumption_ratio | enable_distribution_ratios |
+| combined_charging_ratio | enable_distribution_ratios |
+| combined_standby_ratio | enable_distribution_ratios |
+| combined_cost_rate | calculate_cost_rates |
+| combined_operating_cost_rate | calculate_cost_rates |
+| combined_levelized_cost_rate | calculate_levelized_cost_rates |
+| combined_levelized_operating_cost_rate | calculate_levelized_cost_rates |
+| combined_self_consumption_cost_savings_rate | calculate_cost_saving_rates |
+| combined_cost_savings_rate | calculate_cost_saving_rates |
+| combined_levelized_cost_savings_rate | calculate_levelized_cost_saving_rates |
+| combined_total_operating_costs | accumulate_cost_rates |
+| combined_total_levelized_operating_costs | accumulate_levelized_cost_rates |
+| combined_total_self_consumption_cost_savings | accumulate_cost_saving_rates |
+| combined_total_cost_savings | accumulate_cost_saving_rates |
+| combined_total_levelized_cost_savings | accumulate_levelized_cost_saving_rates |
+| combined_price_of_electricity | *(always on)* |
+| combined_levelized_price_of_electricity | *(always on)* |
+
+`combined_export_compensation_rate` and `combined_total_export_compensation`
+**move to the grid device** (see below) and are removed from the combined scope.
+`combined_export_ratio` stays at combined.
+
+### Grid device
+| Sensor key | Option key | Source property |
+|---|---|---|
+| import_power *(new)* | enable_distribution_power | `grid_adapters_import_power` |
+| export_power *(new)* | enable_distribution_power | `grid_adapters_export_power` |
+| cost_rate | calculate_cost_rates | `grid_adapters_coe_rate` |
+| total_cost | accumulate_cost_rates | (integration of cost_rate) |
+| export_compensation_rate *(moved)* | enable_export_compensation_rate | `grid_adapters_export_compensation_rate` *(new wrapper)* |
+| total_export_compensation *(moved)* | accumulate_export_compensation | (integration of export_compensation_rate) |
+| consumption_ratio | enable_distribution_ratios | `grid_adapters_consumption_ratios` |
+| consumption_share | enable_distribution_shares | `grid_adapters_consumption_shares` |
+
+### PV system / Battery device (per instance)
+| Sensor key | Option key | Capability |
+|---|---|---|
+| export_power | enable_distribution_power | exports_power |
+| self_consumption_power | enable_distribution_power | — |
+| export_compensation_rate | enable_export_compensation_rate | exports_power |
+| total_export_compensation | accumulate_export_compensation | exports_power |
+| operating_cost_rate | calculate_cost_rates | — |
+| levelized_operating_cost_rate | calculate_levelized_cost_rates | lcoe |
+| self_consumption_cost_savings_rate | calculate_cost_saving_rates | — |
+| cost_savings_rate | calculate_cost_saving_rates | — |
+| levelized_cost_savings_rate | calculate_levelized_cost_saving_rates | lcoe |
+| total_operating_costs | accumulate_cost_rates | — |
+| total_levelized_operating_costs | accumulate_levelized_cost_rates | lcoe |
+| total_self_consumption_cost_savings | accumulate_cost_saving_rates | — |
+| total_cost_savings | accumulate_cost_saving_rates | — |
+| total_levelized_cost_savings | accumulate_levelized_cost_saving_rates | lcoe |
+| export_ratio | enable_distribution_ratios | exports_power |
+| self_consumption_ratio | enable_distribution_ratios | — |
+| export_share | enable_distribution_shares | exports_power |
+| self_consumption_share | enable_distribution_shares | — |
+| charging_share_from_&lt;source&gt; *(battery)* | enable_charging_source_shares | — |
+
+### Consumer device (per instance)
+| Sensor key | Option key |
+|---|---|
+| operating_cost_rate | calculate_cost_rates |
+| levelized_operating_cost_rate | calculate_levelized_cost_rates |
+| &lt;source&gt;_ratio | enable_power_source_shares |
+
+### Diagnostics
+| Sensor key | Option key |
+|---|---|
+| available_power | debug_power_entities |
+
+---
+
+## 6. Option storage schema
+
+Flat per‑scope leaf‑key lists; independent, no inheritance.
+
+```python
+entry.options = {
+    "schema": 2,
+    "scopes": {
+        "combined":  [...leaf keys...],
+        "grid":      [...],
+        "pv_system": [...],
+        "battery":   [...],
+        "consumer":  [...],
+    },
+    "debug_power_entities": False,   # global
+}
+```
+
+Resolution (single source of truth):
+
+```python
+def resolve_scope(options: dict, scope: str) -> set[str]:
+    return set(options.get("scopes", {}).get(scope, []))
+```
+
+---
+
+## 7. Read side — scope‑aware gating (`sensor.py`)
+
+`OptionsWrapper` becomes scope‑aware; `_SENSOR_OPTION_GATE` keeps its shape but
+points at the new keys; `_option_gated_out` takes a scope.
+
+```python
+class OptionsWrapper:
+    def __init__(self, options: dict) -> None:
+        self._options = options
+        self._by_scope = {
+            s: resolve_scope(options, s)
+            for s in ("combined", "grid", "pv_system", "battery", "consumer")
+        }
+
+    def check(self, key: str, scope: str = "combined") -> bool:
+        if key == CONF_ENABLE_DEBUG_ENTITIES:
+            return bool(self._options.get(key, False))
+        return key in self._by_scope.get(scope, set())
+
+
+def _option_gated_out(description, options, scope) -> bool:
+    gate = _SENSOR_OPTION_GATE.get(description.key)
+    return gate is not None and not options.check(gate, scope)
+```
+
+Each setup loop passes its scope: hub → `"combined"`, grid → `"grid"`, PV →
+`"pv_system"`, battery → `"battery"`, consumer → `"consumer"`. Dynamic sensors
+pass their owner's scope. `_sync_entity_enabled_state` is unchanged — it already
+disables/re‑enables based on the resolved "wanted" set.
+
+---
+
+## 8. Options flow (`config_flow.py`)
+
+Menu‑driven; accumulate into `self._data`; finish on an explicit Save.
+
+```
+async_step_init → async_show_menu:
+   • combined        (always)
+   • grid            (if grid subentry exists)
+   • pv_system       (if ≥1 PV)
+   • battery         (if ≥1 battery)
+   • consumer        (if ≥1 consumer)
+   • diagnostics     (always)
+   • save            → feasibility check → async_create_entry(data=self._data)
+```
+
+Each `async_step_<scope>` renders the categories from
+`SCOPE_SUPPORTED_OPTIONS[scope]`, pre‑filled from the scope's stored list, and on
+submit writes that scope's list, then returns to the menu
+(`return await self.async_step_init()`). The three multi‑select selectors gain a
+small factory that filters their option list to a scope's supported leaves.
+
+No "use default selection" toggle; each scope is edited directly and
+independently.
+
+---
+
+## 9. Initial config flow seeding (`async_step_user`)
+
+Name‑only step, seeding sensible per‑scope defaults (intersected with each
+scope's supported set):
+
+```python
+DEFAULT_SELECTION = {
+    "calculate_cost_saving_rates",
+    "accumulate_cost_saving_rates",
+    "enable_distribution_power",
+    "enable_distribution_ratios",
+    "enable_distribution_shares",
+    "enable_charging_source_shares",
+    "enable_power_source_shares",
+    "enable_export_compensation_rate",
+    "accumulate_export_compensation",
+}
+options = {
+    "schema": 2,
+    "scopes": {
+        s: sorted(DEFAULT_SELECTION & SCOPE_SUPPORTED_OPTIONS[s])
+        for s in ("combined", "grid", "pv_system", "battery", "consumer")
+    },
+    "debug_power_entities": False,
+}
+```
+
+(Defaults are a starting point — tune before implementation if desired.)
+
+---
+
+## 10. Migration (`MINOR_VERSION` 1 → 2)
+
+Pre‑release, so **history is not preserved** — entities are recreated. Migration
+only needs to leave the entry in the new schema with behaviour roughly matching
+the old global selection. Best‑effort mapping:
+
+```python
+async def async_migrate_entry(hass, entry):
+    if entry.minor_version < 2:
+        old = entry.options
+        old_leaves = set(
+            old.get("calculate_instantaneous_rates", [])
+            + old.get("calculate_instantaneous_saving_rates", [])
+            + old.get("calculate_accumulated_entities", [])
+        )
+        if old.get("enable_power_shares"):
+            old_leaves |= {
+                "enable_distribution_ratios",
+                "enable_distribution_shares",
+                "enable_charging_source_shares",
+                "enable_power_source_shares",
+            }
+        # watt sensors were always-on before → keep them
+        old_leaves.add("enable_distribution_power")
+        # export compensation used to ride on the cost-rate keys
+        if "calculate_cost_rates" in old_leaves:
+            old_leaves.add("enable_export_compensation_rate")
+        if "accumulate_cost_rates" in old_leaves:
+            old_leaves.add("accumulate_export_compensation")
+
+        scopes = {
+            s: sorted(old_leaves & SCOPE_SUPPORTED_OPTIONS[s])
+            for s in ("combined", "grid", "pv_system", "battery", "consumer")
+        }
+        hass.config_entries.async_update_entry(
+            entry,
+            options={
+                "schema": 2,
+                "scopes": scopes,
+                "debug_power_entities": bool(old.get("debug_power_entities", False)),
+            },
+            minor_version=2,
+        )
+    return True
+```
+
+Bump `MINOR_VERSION = 2` in `PowerInsightConfigFlow`.
+
+---
+
+## 11. Engine additions (`power_insight.py`)
+
+Mostly already present:
+
+- `grid_adapters_import_power` → `{grid_uid: combined_grid_import}` ✅ exists
+- `grid_adapters_export_power` → `{grid_uid: combined_grid_export}` ✅ exists
+- **New:** `grid_adapters_export_compensation_rate` →
+  `{grid_uid: combined_export_compensation_rate}` (uid‑keyed wrapper so the grid
+  device can use the standard adapter/integration sensor classes).
+
+No change to the calculation logic — the moved sensors read the same combined
+properties, just attached to the grid device. Add a short comment at the
+`grid_adapter` slot documenting that **one grid per entry is intentional**, and
+keep the `grid_already_configured` config‑flow guard.
+
+---
+
+## 12. Sensor platform changes (`sensor.py`)
+
+- Add grid `import_power` / `export_power` descriptions to
+  `POWER_INSIGHT_GRID_ADAPTER_SENSORS` (value_fn → the uid‑keyed grid power
+  props; standard `PowerInsightAdapterSensor`).
+- Move `export_compensation_rate` (rate) into
+  `POWER_INSIGHT_GRID_ADAPTER_SENSORS` and `total_export_compensation` into
+  `POWER_INSIGHT_GRID_ADAPTER_INTEGRATION_SENSORS`; remove the two combined
+  export descriptions from the hub tuples.
+- Update `_SENSOR_OPTION_GATE` to the new keys (section 5).
+- Pass the scope into `_option_gated_out` / `OptionsWrapper.check` in each loop;
+  gate the dynamic battery (`enable_charging_source_shares`) and consumer
+  (`enable_power_source_shares`) sensors accordingly.
+- `_sync_entity_enabled_state`, `_add` accumulation: unchanged.
+
+---
+
+## 13. Feasibility check (per scope)
+
+`check_options_feasibility` evaluates each subentry against **its scope's**
+resolved options: e.g. enabling levelized categories for `pv_system` requires
+each PV's lifetime values; enabling cost rates for `grid` requires a price
+entity on the grid. Errors name the specific device type + missing data.
+
+---
+
+## 14. Translations (`en.json`)
+
+Add under `options.step`:
+- `init` — menu title + `menu_options` (combined, grid, pv_system, battery,
+  consumer, diagnostics, save).
+- one step per scope with `data` / `data_description` for the categories it
+  shows.
+- `save` step (confirmation).
+
+Add `data` labels/descriptions for all new category keys. Remove obsolete
+`enable_power_shares` strings.
+
+---
+
+## 15. Testing plan
+
+- **Migration:** old flat options → new `scopes` shape; `minor_version == 2`.
+- **Resolution:** `resolve_scope` returns the right set; absent scope → empty.
+- **Per‑type gating:** a PV override enabling levelized creates PV levelized
+  sensors; battery (not enabled) does not. Grid gets import/export power +
+  export compensation; combined no longer has export compensation.
+- **Disable/re‑enable** across a per‑scope options change (extend the existing
+  `test_disabling_option_disables_entity_but_keeps_it`).
+- **Feasibility:** levelized enabled for `pv_system` with a PV missing lifetime
+  values flags that PV only.
+- **Flow:** menu lists only present device types; each scope step round‑trips.
+- Update `tests/conftest.py` `BASE_OPTIONS` / `FULL_OPTIONS` to the new schema.
+
+---
+
+## 16. Out of scope / future
+
+- **CO₂ track.** `calculate_co2_*` / `accumulate_co2_*` constants exist but are
+  unwired. This taxonomy has room for a parallel "CO₂ rates / savings / totals"
+  set of categories per scope when the engine side is ready.
+- **Multiple grids in one entry.** Not supported and not planned — two grid
+  connections are modelled as two config entries.
+
+---
+
+## 17. Implementation checklist (file by file)
+
+- `const.py` — new option keys; `SCOPE_SUPPORTED_OPTIONS`; remove
+  `enable_power_shares` + container keys; note CO₂ keys remain dormant.
+- `power_insight.py` — `grid_adapters_export_compensation_rate` wrapper; comment
+  on single‑grid intent.
+- `sensor.py` — grid import/export power + moved export‑compensation sensors;
+  `_SENSOR_OPTION_GATE` remap; scope‑aware `OptionsWrapper`/`_option_gated_out`;
+  dynamic‑sensor scope gating.
+- `config_flow.py` — menu options flow with per‑scope steps; scope‑filtered
+  selectors; per‑scope feasibility; `MINOR_VERSION = 2`; updated initial seeding.
+- `__init__.py` — `async_migrate_entry` implementation.
+- `translations/en.json` — menu + per‑scope steps + new category strings.
+- `tests/` — conftest option fixtures; migration, per‑scope gating, flow tests.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,29 @@ BASE_OPTIONS = {
     "calculate_instantaneous_rates": [],
     "calculate_instantaneous_saving_rates": [],
     "calculate_accumulated_entities": [],
+    # Fresh installs seed the power-share option to True from the field default.
+    "enable_power_shares": True,
+}
+
+# Every sensor group enabled — used by tests that assert a specific rate /
+# total / levelized sensor exists, since those are now gated by their option.
+FULL_OPTIONS = {
+    "calculate_instantaneous_rates": [
+        "calculate_cost_rates",
+        "calculate_levelized_cost_rates",
+    ],
+    "calculate_instantaneous_saving_rates": [
+        "calculate_cost_saving_rates",
+        "calculate_levelized_cost_saving_rates",
+    ],
+    "calculate_accumulated_entities": [
+        "accumulate_cost_rates",
+        "accumulate_levelized_cost_rates",
+        "accumulate_cost_saving_rates",
+        "accumulate_levelized_cost_saving_rates",
+    ],
+    "enable_power_shares": True,
+    "debug_power_entities": False,
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,32 +25,75 @@ GRID_SUB_ID = "01GRID00000000000000000001"
 PV_SUB_ID = "01PV0000000000000000000001"
 BAT_SUB_ID = "01BAT00000000000000000001A"
 
+# Per-scope options schema (v2). Each scope lists the enabled leaf option keys.
+
+# Base: only the always-visible power-distribution sensors enabled.
 BASE_OPTIONS = {
-    "calculate_instantaneous_rates": [],
-    "calculate_instantaneous_saving_rates": [],
-    "calculate_accumulated_entities": [],
-    # Fresh installs seed the power-share option to True from the field default.
-    "enable_power_shares": True,
+    "schema": 2,
+    "scopes": {
+        "combined": ["enable_distribution_power", "enable_distribution_ratios"],
+        "grid": [
+            "enable_distribution_power",
+            "enable_distribution_ratios",
+            "enable_distribution_shares",
+        ],
+        "pv_system": [
+            "enable_distribution_power",
+            "enable_distribution_ratios",
+            "enable_distribution_shares",
+        ],
+        "battery": [
+            "enable_distribution_power",
+            "enable_distribution_ratios",
+            "enable_distribution_shares",
+            "enable_charging_source_shares",
+        ],
+        "consumer": ["enable_power_source_shares"],
+    },
+    "debug_power_entities": False,
 }
 
-# Every sensor group enabled — used by tests that assert a specific rate /
-# total / levelized sensor exists, since those are now gated by their option.
+# Every supported category enabled per scope — used by tests asserting a
+# specific rate / total / levelized sensor exists.
 FULL_OPTIONS = {
-    "calculate_instantaneous_rates": [
-        "calculate_cost_rates",
-        "calculate_levelized_cost_rates",
-    ],
-    "calculate_instantaneous_saving_rates": [
-        "calculate_cost_saving_rates",
-        "calculate_levelized_cost_saving_rates",
-    ],
-    "calculate_accumulated_entities": [
-        "accumulate_cost_rates",
-        "accumulate_levelized_cost_rates",
-        "accumulate_cost_saving_rates",
-        "accumulate_levelized_cost_saving_rates",
-    ],
-    "enable_power_shares": True,
+    "schema": 2,
+    "scopes": {
+        "combined": [
+            "calculate_cost_rates", "calculate_levelized_cost_rates",
+            "calculate_cost_saving_rates", "calculate_levelized_cost_saving_rates",
+            "accumulate_cost_rates", "accumulate_levelized_cost_rates",
+            "accumulate_cost_saving_rates", "accumulate_levelized_cost_saving_rates",
+            "enable_distribution_power", "enable_distribution_ratios",
+        ],
+        "grid": [
+            "calculate_cost_rates", "accumulate_cost_rates",
+            "enable_export_compensation_rate", "accumulate_export_compensation",
+            "enable_distribution_power", "enable_distribution_ratios",
+            "enable_distribution_shares",
+        ],
+        "pv_system": [
+            "calculate_cost_rates", "calculate_levelized_cost_rates",
+            "calculate_cost_saving_rates", "calculate_levelized_cost_saving_rates",
+            "enable_export_compensation_rate", "accumulate_export_compensation",
+            "accumulate_cost_rates", "accumulate_levelized_cost_rates",
+            "accumulate_cost_saving_rates", "accumulate_levelized_cost_saving_rates",
+            "enable_distribution_power", "enable_distribution_ratios",
+            "enable_distribution_shares",
+        ],
+        "battery": [
+            "calculate_cost_rates", "calculate_levelized_cost_rates",
+            "calculate_cost_saving_rates", "calculate_levelized_cost_saving_rates",
+            "enable_export_compensation_rate", "accumulate_export_compensation",
+            "accumulate_cost_rates", "accumulate_levelized_cost_rates",
+            "accumulate_cost_saving_rates", "accumulate_levelized_cost_saving_rates",
+            "enable_distribution_power", "enable_distribution_ratios",
+            "enable_distribution_shares", "enable_charging_source_shares",
+        ],
+        "consumer": [
+            "calculate_cost_rates", "calculate_levelized_cost_rates",
+            "enable_power_source_shares",
+        ],
+    },
     "debug_power_entities": False,
 }
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -49,14 +49,14 @@ async def test_user_step_creates_entry(hass: HomeAssistant) -> None:
     )
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "Test PowerInsight"
-    # Fresh installs default to cost-savings rates + accumulated totals.
-    assert result["options"]["calculate_instantaneous_rates"] == []
-    assert result["options"]["calculate_instantaneous_saving_rates"] == [
-        "calculate_cost_saving_rates"
-    ]
-    assert result["options"]["calculate_accumulated_entities"] == [
-        "accumulate_cost_saving_rates"
-    ]
+    # Fresh installs seed the per-scope schema with sensible defaults.
+    options = result["options"]
+    assert options["schema"] == 2
+    combined = options["scopes"]["combined"]
+    assert "calculate_cost_saving_rates" in combined
+    assert "enable_distribution_power" in combined
+    # Grid has no savings sensors, so it only gets its supported defaults.
+    assert "calculate_cost_saving_rates" not in options["scopes"]["grid"]
 
 
 # ---------------------------------------------------------------------------
@@ -292,8 +292,8 @@ async def test_subentry_pv_creates_subentry(hass: HomeAssistant) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_options_flow_shows_form(hass: HomeAssistant) -> None:
-    """The options flow init step should show a form with current options."""
+async def test_options_flow_shows_menu(hass: HomeAssistant) -> None:
+    """The options flow init step shows the per-scope section menu."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="My PowerInsight",
@@ -303,12 +303,19 @@ async def test_options_flow_shows_form(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] == FlowResultType.MENU
     assert result["step_id"] == "init"
+    # Combined + grid (present) + diagnostics + save; no pv/battery/consumer.
+    assert "combined" in result["menu_options"]
+    assert "grid" in result["menu_options"]
+    assert "save" in result["menu_options"]
+    assert "battery" not in result["menu_options"]
 
 
-async def test_options_flow_saves_updated_options(hass: HomeAssistant) -> None:
-    """Submitting the options form should persist the new option values."""
+async def test_options_flow_edits_grid_scope_and_saves(
+    hass: HomeAssistant,
+) -> None:
+    """Editing the grid scope then saving persists the per-scope selection."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="My PowerInsight",
@@ -318,16 +325,38 @@ async def test_options_flow_saves_updated_options(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
+    # Open the grid section from the menu.
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "grid"}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "grid"
+
+    # Enable the grid cost rate; turn distribution off.
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "calculate_instantaneous_rates": [],
-            "calculate_instantaneous_saving_rates": [],
-            "calculate_accumulated_entities": [],
-            "debug_power_entities": True,
-            "enable_power_shares": True,
+            "cost_rates": ["calculate_cost_rates"],
+            "accumulated_costs": [],
+            "export_compensation": [],
+            "distribution_power": False,
+            "distribution_ratios": False,
+            "distribution_shares": False,
         },
     )
+    # Back at the menu; now save.
+    assert result["type"] == FlowResultType.MENU
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "save"}
+    )
+    # Grid has no price entity, so enabling a cost rate warns; confirm to apply.
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "save"
+    assert result["errors"]["base"] == "reconfigure_adapters_first"
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={}
+    )
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert entry.options.get("debug_power_entities") is True
-    assert entry.options.get("enable_power_shares") is True
+
+    assert entry.options["scopes"]["grid"] == ["calculate_cost_rates"]
+    assert entry.options["schema"] == 2

--- a/tests/test_config_simplification.py
+++ b/tests/test_config_simplification.py
@@ -1,66 +1,79 @@
-"""Tests for the config-flow simplification and field audit (items A & B)."""
+"""Tests for the per-scope options categories and adapter field audit."""
 from __future__ import annotations
 
 import pytest
 
 from custom_components.power_insight.config_flow import (
     BATTERY_FIELDS,
-    CONFIG_ENTRY_FIELDS,
-    INSTANTANEOUS_RATES_SELECTOR,
-    INSTANTANEOUS_SAVING_RATES_SELECTOR,
-    ACCUMULATED_ENTITIES_SELECTOR,
+    OPTION_CATEGORIES,
+    DEFAULT_SELECTION,
+    default_scopes,
+    build_scope_schema,
+    collect_scope_selection,
 )
 from custom_components.power_insight.const import (
     CONF_POWER_ENTITY,
-    CONF_CALCULATE_INSTANTANEOUS_RATES,
-    CONF_CALCULATE_INSTANTANEOUS_SAVING_RATES,
-    CONF_CALCULATE_ACCUMULATED_ENTITIES,
-    CONF_CALCULATE_COST_SAVING_RATES,
-    CONF_ACCUMULATE_COST_SAVING_RATES,
+    SCOPES,
+    SCOPE_SUPPORTED_OPTIONS,
 )
 
 pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
 
 
-def _option_values(select_selector) -> set[str]:
-    return {opt["value"] for opt in select_selector.config["options"]}
+def _all_category_leaves() -> set[str]:
+    return {leaf for cat in OPTION_CATEGORIES for leaf, _ in cat.leaves}
 
 
-# --- A1: the three multiselects are options-only with new defaults ---
+# --- Categories only expose supported leaves, never CO2 ---
 
-def test_multiselects_are_options_only() -> None:
-    for key in (
-        CONF_CALCULATE_INSTANTANEOUS_RATES,
-        CONF_CALCULATE_INSTANTANEOUS_SAVING_RATES,
-        CONF_CALCULATE_ACCUMULATED_ENTITIES,
-    ):
-        field = CONFIG_ENTRY_FIELDS[key]
-        assert field.in_config_flow is False
-        assert field.in_options_flow is True
+def test_categories_have_no_co2_options() -> None:
+    assert not any("co2" in leaf for leaf in _all_category_leaves())
 
 
-def test_fresh_install_defaults() -> None:
-    assert CONFIG_ENTRY_FIELDS[CONF_CALCULATE_INSTANTANEOUS_RATES].default == []
-    assert CONFIG_ENTRY_FIELDS[
-        CONF_CALCULATE_INSTANTANEOUS_SAVING_RATES
-    ].default == [CONF_CALCULATE_COST_SAVING_RATES]
-    assert CONFIG_ENTRY_FIELDS[
-        CONF_CALCULATE_ACCUMULATED_ENTITIES
-    ].default == [CONF_ACCUMULATE_COST_SAVING_RATES]
+def test_every_supported_leaf_has_a_category() -> None:
+    """Each leaf a scope supports must be reachable through some category."""
+    category_leaves = _all_category_leaves()
+    for scope in SCOPES:
+        missing = SCOPE_SUPPORTED_OPTIONS[scope] - category_leaves
+        assert not missing, f"{scope} supports uncategorised leaves: {missing}"
 
 
-# --- A2: CO2 options stripped from the three selectors ---
+# --- Fresh-install defaults are sane and scope-filtered ---
 
-def test_selectors_have_no_co2_options() -> None:
-    for selector in (
-        INSTANTANEOUS_RATES_SELECTOR,
-        INSTANTANEOUS_SAVING_RATES_SELECTOR,
-        ACCUMULATED_ENTITIES_SELECTOR,
-    ):
-        assert not any("co2" in value for value in _option_values(selector))
+def test_default_scopes_are_subsets_of_support() -> None:
+    scopes = default_scopes()
+    assert set(scopes) == set(SCOPES)
+    for scope, leaves in scopes.items():
+        assert set(leaves) <= SCOPE_SUPPORTED_OPTIONS[scope]
+        assert set(leaves) <= DEFAULT_SELECTION
 
 
-# --- B1: battery power entity is required ---
+def test_default_includes_cost_savings_and_distribution() -> None:
+    combined = set(default_scopes()["combined"])
+    assert "calculate_cost_saving_rates" in combined
+    assert "enable_distribution_power" in combined
+
+
+# --- Scope schema build / collect round-trips ---
+
+def test_scope_schema_round_trip() -> None:
+    """Selecting every supported leaf and reading it back is loss-free."""
+    for scope in SCOPES:
+        supported = SCOPE_SUPPORTED_OPTIONS[scope]
+        schema = build_scope_schema(scope, supported)
+        # Build a user_input that selects everything shown in the schema.
+        user_input: dict = {}
+        for cat in OPTION_CATEGORIES:
+            shown = [lk for lk, _ in cat.leaves if lk in supported]
+            if not shown:
+                continue
+            user_input[cat.field] = True if cat.toggle else shown
+        collected = set(collect_scope_selection(scope, user_input))
+        assert collected == set(supported)
+        assert schema is not None
+
+
+# --- Battery power entity is required ---
 
 def test_battery_power_entity_required() -> None:
     assert BATTERY_FIELDS[CONF_POWER_ENTITY].required is True

--- a/tests/test_correction_flow.py
+++ b/tests/test_correction_flow.py
@@ -12,6 +12,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from .conftest import (
     DOMAIN,
     BASE_OPTIONS,
+    FULL_OPTIONS,
     PV_SUB_ID,
     GRID_SUB_ID,
     make_grid_subentry_data,
@@ -111,7 +112,7 @@ async def test_levelized_sensors_present_with_lcoe(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="My PowerInsight",
-        options=BASE_OPTIONS,
+        options=FULL_OPTIONS,
         subentries_data=[make_grid_subentry_data(), make_pv_subentry_data()],
     )
     hass.states.async_set("sensor.grid_power", "0", {"unit_of_measurement": "W"})
@@ -141,7 +142,7 @@ async def test_levelized_measurement_scaled_by_factor(hass: HomeAssistant) -> No
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="My PowerInsight",
-        options=BASE_OPTIONS,
+        options=FULL_OPTIONS,
         subentries_data=[grid_data, pv_data],
     )
     hass.states.async_set(

--- a/tests/test_correction_flow.py
+++ b/tests/test_correction_flow.py
@@ -177,19 +177,14 @@ async def test_combined_ledger_sensor_includes_retired_totals(
     hass: HomeAssistant,
 ) -> None:
     """The combined derived sensor adds the frozen retired-adapter totals."""
-    from custom_components.power_insight.const import (
-        CONF_CALCULATE_ACCUMULATED_ENTITIES,
-        CONF_ACCUMULATE_LEVELIZED_COST_RATES,
-        CONF_RETIRED_ADAPTERS,
-    )
+    from custom_components.power_insight.const import CONF_RETIRED_ADAPTERS
 
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="My PowerInsight",
         options={
-            CONF_CALCULATE_ACCUMULATED_ENTITIES: [
-                CONF_ACCUMULATE_LEVELIZED_COST_RATES
-            ],
+            "schema": 2,
+            "scopes": {"combined": ["accumulate_levelized_cost_rates"]},
         },
         data={
             CONF_RETIRED_ADAPTERS: [

--- a/tests/test_currency.py
+++ b/tests/test_currency.py
@@ -15,7 +15,7 @@ from custom_components.power_insight.config_flow import (
 from custom_components.power_insight.sensor import _resolve_currency_unit
 from .conftest import (
     DOMAIN,
-    BASE_OPTIONS,
+    FULL_OPTIONS,
     PV_SUB_ID,
     make_grid_subentry_data,
     make_pv_subentry_data,
@@ -69,7 +69,7 @@ async def test_sensor_units_follow_currency(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="My PowerInsight",
-        options=BASE_OPTIONS,
+        options=FULL_OPTIONS,
         subentries_data=[grid, make_pv_subentry_data()],
     )
     hass.states.async_set("sensor.grid_power", "1000", {"unit_of_measurement": "W"})

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -84,12 +84,16 @@ async def test_e2e_instantaneous_sensor_values(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         title="My PowerInsight",
         options={
-            "calculate_instantaneous_rates": [
-                "calculate_cost_rates",
-                "calculate_levelized_cost_rates",
-            ],
-            "calculate_instantaneous_saving_rates": [],
-            "calculate_accumulated_entities": [],
+            "schema": 2,
+            "scopes": {
+                "combined": [
+                    "calculate_cost_rates", "calculate_levelized_cost_rates",
+                ],
+                "grid": ["calculate_cost_rates"],
+                "pv_system": [
+                    "calculate_cost_rates", "calculate_levelized_cost_rates",
+                ],
+            },
         },
         subentries_data=[_grid_with_price(), pv],
     )
@@ -129,9 +133,10 @@ async def test_e2e_accumulated_value_over_time(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         title="My PowerInsight",
         options={
-            "calculate_instantaneous_rates": ["calculate_cost_rates"],
-            "calculate_instantaneous_saving_rates": [],
-            "calculate_accumulated_entities": ["accumulate_cost_rates"],
+            "schema": 2,
+            "scopes": {
+                "grid": ["calculate_cost_rates", "accumulate_cost_rates"],
+            },
         },
         subentries_data=[_grid_with_price(), make_pv_subentry_data()],
     )
@@ -168,9 +173,11 @@ async def test_e2e_removal_ledger_lifecycle(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         title="My PowerInsight",
         options={
-            "calculate_instantaneous_rates": [],
-            "calculate_instantaneous_saving_rates": [],
-            "calculate_accumulated_entities": ["accumulate_levelized_cost_rates"],
+            "schema": 2,
+            "scopes": {
+                "combined": ["accumulate_levelized_cost_rates"],
+                "pv_system": ["accumulate_levelized_cost_rates"],
+            },
         },
         subentries_data=[_grid_with_price(), make_pv_subentry_data()],
     )

--- a/tests/test_integration_setup.py
+++ b/tests/test_integration_setup.py
@@ -28,6 +28,42 @@ async def test_setup_standby_without_grid(
     assert mock_config_entry_no_grid.state == ConfigEntryState.LOADED
 
 
+async def test_migrate_flat_options_to_scopes(hass: HomeAssistant) -> None:
+    """A v1 entry with flat options is migrated to the v2 per-scope schema."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My PowerInsight",
+        version=1,
+        minor_version=1,
+        options={
+            "calculate_instantaneous_rates": ["calculate_cost_rates"],
+            "calculate_instantaneous_saving_rates": [],
+            "calculate_accumulated_entities": ["accumulate_cost_rates"],
+            "enable_power_shares": True,
+            "debug_power_entities": True,
+        },
+        subentries_data=[make_grid_subentry_data()],
+    )
+    hass.states.async_set("sensor.grid_power", "0", {"unit_of_measurement": "W"})
+    await setup_integration(hass, entry)
+
+    assert entry.minor_version == 2
+    assert entry.options["schema"] == 2
+    grid = set(entry.options["scopes"]["grid"])
+    # Cost rate + its accumulation carried over to the grid scope.
+    assert "calculate_cost_rates" in grid
+    assert "accumulate_cost_rates" in grid
+    # Power shares expanded into the grid distribution categories.
+    assert "enable_distribution_ratios" in grid
+    assert "enable_distribution_shares" in grid
+    # Watt sensors kept (were always-on before).
+    assert "enable_distribution_power" in grid
+    assert entry.options["debug_power_entities"] is True
+    # Levelized was not enabled, so it must not appear anywhere.
+    all_leaves = {l for s in entry.options["scopes"].values() for l in s}
+    assert not any("levelized" in leaf for leaf in all_leaves)
+
+
 async def test_no_grid_creates_repair_issue(
     hass: HomeAssistant, mock_config_entry_no_grid: MockConfigEntry
 ) -> None:

--- a/tests/test_sensor_entities.py
+++ b/tests/test_sensor_entities.py
@@ -12,6 +12,7 @@ from .conftest import (
     PV_SUB_ID,
     BAT_SUB_ID,
     BASE_OPTIONS,
+    FULL_OPTIONS,
     make_grid_subentry_data,
     make_pv_subentry_data,
     make_battery_subentry_data,
@@ -183,6 +184,35 @@ async def test_disabling_option_disables_entity_but_keeps_it(
     await hass.async_block_till_done()
 
     assert ent_reg.async_get(entity_id).disabled_by is None
+
+
+async def test_grid_owns_import_export_and_compensation_sensors(
+    hass: HomeAssistant,
+) -> None:
+    """Import/export power and export compensation live on the grid device,
+    and the combined export-compensation sensors are gone from the hub."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My PowerInsight",
+        options=FULL_OPTIONS,
+        subentries_data=[make_grid_subentry_data(), make_pv_subentry_data()],
+    )
+    hass.states.async_set("sensor.grid_power", "0", {"unit_of_measurement": "W"})
+    hass.states.async_set("sensor.pv_power", "0", {"unit_of_measurement": "W"})
+    await setup_integration(hass, entry)
+
+    entries = get_entry_entities(hass, entry)
+    uids = {e.unique_id for e in entries if e.unique_id}
+    grid = f"{entry.entry_id}_{GRID_SUB_ID}"
+
+    assert f"{grid}_import_power" in uids
+    assert f"{grid}_export_power" in uids
+    assert f"{grid}_export_compensation_rate" in uids
+    assert f"{grid}_total_export_compensation" in uids
+
+    # Export compensation no longer exists at the combined/hub level.
+    assert f"{entry.entry_id}_combined_export_compensation_rate" not in uids
+    assert f"{entry.entry_id}_combined_total_export_compensation" not in uids
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor_entities.py
+++ b/tests/test_sensor_entities.py
@@ -8,6 +8,13 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from .conftest import (
     DOMAIN,
+    GRID_SUB_ID,
+    PV_SUB_ID,
+    BAT_SUB_ID,
+    BASE_OPTIONS,
+    make_grid_subentry_data,
+    make_pv_subentry_data,
+    make_battery_subentry_data,
     setup_integration,
 )
 
@@ -100,6 +107,41 @@ async def test_pv_adapter_sensors_created(
     pv_prefix = f"{mock_config_entry_with_pv.entry_id}_{PV_SUB_ID}"
     pv_sensors = [uid for uid in unique_ids if uid and uid.startswith(pv_prefix)]
     assert len(pv_sensors) > 0, "Expected at least one PV adapter sensor"
+
+
+async def test_battery_charging_share_sensors_only_for_selected_sources(
+    hass: HomeAssistant,
+) -> None:
+    """A battery should only get a "charging share from X" sensor for each
+    source it is actually configured to charge from.
+
+    Here the battery may charge from the grid but NOT from the PV system, so
+    only the grid charging-share sensor should exist.
+    """
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My PowerInsight",
+        options=BASE_OPTIONS,
+        subentries_data=[
+            make_grid_subentry_data(),
+            make_pv_subentry_data(),
+            make_battery_subentry_data(charge_from_adapters=[GRID_SUB_ID]),
+        ],
+    )
+    for ent in ("grid_power", "pv_power", "battery_power"):
+        hass.states.async_set(f"sensor.{ent}", "0", {"unit_of_measurement": "W"})
+    await setup_integration(hass, entry)
+
+    entries = get_entry_entities(hass, entry)
+    keys = {e.unique_id for e in entries if e.unique_id}
+
+    bat_prefix = f"{entry.entry_id}_{BAT_SUB_ID}_charging_share_from_"
+    charging_share_keys = {k for k in keys if k.startswith(bat_prefix)}
+
+    # Exactly one charging-share sensor (Grid), none for the unselected PV.
+    assert charging_share_keys == {f"{bat_prefix}Grid"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor_entities.py
+++ b/tests/test_sensor_entities.py
@@ -144,6 +144,47 @@ async def test_battery_charging_share_sensors_only_for_selected_sources(
     assert charging_share_keys == {f"{bat_prefix}Grid"}
 
 
+async def test_disabling_option_disables_entity_but_keeps_it(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Turning an option off should disable (not delete) the matching sensors,
+    and turning it back on should re-enable them.
+
+    Power-share sensors are gated on ``enable_power_shares``; toggling it must
+    therefore take effect on the registered entities.
+    """
+    hass.states.async_set(
+        "sensor.grid_power", "0", {"unit_of_measurement": "W"}
+    )
+    await setup_integration(hass, mock_config_entry)
+    ent_reg = er.async_get(hass)
+
+    uid = f"{mock_config_entry.entry_id}_combined_export_ratio"
+    entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, uid)
+    assert entity_id is not None
+    assert ent_reg.async_get(entity_id).disabled_by is None
+
+    # Turn power shares off → the entity is kept but disabled by the integration.
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        options={**mock_config_entry.options, "enable_power_shares": False},
+    )
+    await hass.async_block_till_done()
+
+    reg_entry = ent_reg.async_get(entity_id)
+    assert reg_entry is not None, "entity should be kept, not deleted"
+    assert reg_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+    # Turn it back on → the integration re-enables the entity.
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        options={**mock_config_entry.options, "enable_power_shares": True},
+    )
+    await hass.async_block_till_done()
+
+    assert ent_reg.async_get(entity_id).disabled_by is None
+
+
 # ---------------------------------------------------------------------------
 # State update tests
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor_entities.py
+++ b/tests/test_sensor_entities.py
@@ -165,10 +165,16 @@ async def test_disabling_option_disables_entity_but_keeps_it(
     assert entity_id is not None
     assert ent_reg.async_get(entity_id).disabled_by is None
 
-    # Turn power shares off → the entity is kept but disabled by the integration.
+    def _with_combined(leaves: list[str]) -> dict:
+        opts = {**mock_config_entry.options}
+        opts["scopes"] = {**opts["scopes"], "combined": leaves}
+        return opts
+
+    # Drop distribution ratios from the combined scope → the entity is kept
+    # but disabled by the integration.
     hass.config_entries.async_update_entry(
         mock_config_entry,
-        options={**mock_config_entry.options, "enable_power_shares": False},
+        options=_with_combined(["enable_distribution_power"]),
     )
     await hass.async_block_till_done()
 
@@ -176,10 +182,12 @@ async def test_disabling_option_disables_entity_but_keeps_it(
     assert reg_entry is not None, "entity should be kept, not deleted"
     assert reg_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
-    # Turn it back on → the integration re-enables the entity.
+    # Re-enable → the integration re-enables the entity.
     hass.config_entries.async_update_entry(
         mock_config_entry,
-        options={**mock_config_entry.options, "enable_power_shares": True},
+        options=_with_combined(
+            ["enable_distribution_power", "enable_distribution_ratios"]
+        ),
     )
     await hass.async_block_till_done()
 


### PR DESCRIPTION
## Summary

This PR implements the options flow redesign (step 2) to reorganize sensor configuration into human-readable, per-scope categories. It consolidates grid import/export sensors onto a single grid device, splits the monolithic `enable_power_shares` toggle into four granular power-distribution categories, and separates export compensation into its own category.

## Key Changes

**Options Flow Restructuring:**
- Replaced flat options structure with per-scope schema: `options["scopes"][scope] = [enabled_leaf_keys]`
- Introduced `OptionCategory` dataclass to map user-facing categories to leaf option keys
- Implemented scope-aware options flow menu with sections for: combined, grid, pv_system, battery, consumer, and diagnostics
- Each scope only shows categories it supports via `SCOPE_SUPPORTED_OPTIONS` mapping

**New Option Keys:**
- Split `enable_power_shares` into:
  - `enable_distribution_power` (watt split)
  - `enable_distribution_ratios` (percentage of own power)
  - `enable_distribution_shares` (percentage of combined)
  - `enable_charging_source_shares` (battery-specific)
  - `enable_power_source_shares` (consumer-specific)
- Extracted export compensation into separate keys:
  - `enable_export_compensation_rate`
  - `accumulate_export_compensation`

**Grid Device Consolidation:**
- Moved `combined_export_compensation_rate` and `combined_total_export_compensation` sensors to grid device
- Added `import_power` and `export_power` sensors to grid device (both sides of the meter)
- Grid device now owns both import (cost) and export (compensation + power) functionality

**Sensor Gating Updates:**
- Removed `exists_fn` checks from sensor descriptions (now handled by option gating)
- Sensors are gated by their corresponding leaf option keys via `_SENSOR_OPTION_GATE`
- Capability gates (e.g., `exports_power`, `lcoe`) still apply in addition to option gates

**Migration:**
- Added `_migrate_options_to_scopes()` to convert v1 flat options to v2 per-scope schema
- Migration distributes old global selection into each scope, intersected with scope support
- No history-preserving migration required (pre-release)

**Configuration Defaults:**
- Fresh installs seed per-scope defaults via `default_scopes()` function
- Defaults include cost-savings rates, power distribution, and export compensation
- Each scope receives only its supported subset of defaults

## Implementation Details

- `SCOPE_SUPPORTED_OPTIONS` dict defines which leaf keys each scope supports
- `build_scope_schema()` dynamically constructs per-scope forms with only supported categories
- `collect_scope_selection()` extracts enabled leaves from user input
- Translations updated to reflect new category labels and descriptions
- Test fixtures updated to use new `BASE_OPTIONS` and `FULL_OPTIONS` with per-scope structure
- Battery charging-share sensors only created for configured charge sources

https://claude.ai/code/session_019memJbURkLJkEMqsqUowQk