### PR TITLE
Save options per section on submit (no separate save step)

### DIFF
--- a/custom_components/power_insight/config_flow.py
+++ b/custom_components/power_insight/config_flow.py
@@ -1513,24 +1513,28 @@ class PowerInsightOptionsFlow(OptionsFlow):
     """Per-scope options flow.
 
     A menu offers the whole-home (combined) scope plus one section per
-    configured device type, then a diagnostics section and a save action. Each
-    section edits only the categories that scope supports. The working
-    selection is accumulated across steps and written on save.
+    configured device type, and a diagnostics section. Each section shows only
+    the categories its scope supports and is **saved immediately on submit** —
+    there is no separate save step, so "Submit" always persists. When the
+    submitted selection needs data a device has not provided yet, a confirm
+    step lets the user save anyway and reconfigure the device afterwards.
     """
 
     def __init__(self) -> None:
-        """Initialise the working selection lazily."""
-        self._scopes: dict[str, set[str]] | None = None
-        self._debug: bool = False
+        """Initialise the pending-confirm buffer."""
+        self._pending: dict | None = None
 
-    def _load(self) -> None:
-        """Load the working selection from the stored options once."""
-        if self._scopes is not None:
-            return
+    def _current_options(self) -> dict:
+        """Return a fresh, mutable copy of the stored options (v2 shape)."""
         options = self.config_entry.options
         stored = options.get("scopes", {})
-        self._scopes = {scope: set(stored.get(scope, [])) for scope in SCOPES}
-        self._debug = bool(options.get(CONF_ENABLE_DEBUG_ENTITIES, False))
+        return {
+            "schema": 2,
+            "scopes": {scope: list(stored.get(scope, [])) for scope in SCOPES},
+            CONF_ENABLE_DEBUG_ENTITIES: bool(
+                options.get(CONF_ENABLE_DEBUG_ENTITIES, False)
+            ),
+        }
 
     def _present_device_scopes(self) -> list[str]:
         """Return device-type scopes that have at least one subentry."""
@@ -1544,28 +1548,27 @@ class PowerInsightOptionsFlow(OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Show the section menu."""
-        self._load()
         return self.async_show_menu(
             step_id="init",
             menu_options=[
                 SCOPE_COMBINED,
                 *self._present_device_scopes(),
                 "diagnostics",
-                "save",
             ],
         )
 
     async def _async_scope_step(
         self, scope: str, user_input: dict[str, Any] | None
     ) -> FlowResult:
-        """Render / collect one scope's category selection."""
-        self._load()
+        """Render a scope's categories, saving the selection on submit."""
         if user_input is not None:
-            self._scopes[scope] = set(collect_scope_selection(scope, user_input))
-            return await self.async_step_init()
+            options = self._current_options()
+            options["scopes"][scope] = collect_scope_selection(scope, user_input)
+            return await self._save(options)
+        current = set(self.config_entry.options.get("scopes", {}).get(scope, []))
         return self.async_show_form(
             step_id=scope,
-            data_schema=build_scope_schema(scope, self._scopes[scope]),
+            data_schema=build_scope_schema(scope, current),
         )
 
     async def async_step_combined(self, user_input=None) -> FlowResult:
@@ -1589,42 +1592,37 @@ class PowerInsightOptionsFlow(OptionsFlow):
         return await self._async_scope_step("consumer", user_input)
 
     async def async_step_diagnostics(self, user_input=None) -> FlowResult:
-        """Edit the global diagnostics toggle."""
-        self._load()
+        """Edit the global diagnostics toggle, saving on submit."""
         if user_input is not None:
-            self._debug = bool(user_input.get(CONF_ENABLE_DEBUG_ENTITIES, False))
-            return await self.async_step_init()
+            options = self._current_options()
+            options[CONF_ENABLE_DEBUG_ENTITIES] = bool(
+                user_input.get(CONF_ENABLE_DEBUG_ENTITIES, False)
+            )
+            return await self._save(options)
+        debug = bool(self.config_entry.options.get(CONF_ENABLE_DEBUG_ENTITIES, False))
         return self.async_show_form(
             step_id="diagnostics",
             data_schema=vol.Schema({
-                vol.Required(
-                    CONF_ENABLE_DEBUG_ENTITIES, default=self._debug
-                ): BOOLEAN_SELECTOR,
+                vol.Required(CONF_ENABLE_DEBUG_ENTITIES, default=debug): BOOLEAN_SELECTOR,
             }),
         )
 
-    def _compose(self) -> dict:
-        """Build the options dict from the working selection."""
-        return {
-            "schema": 2,
-            "scopes": {scope: sorted(self._scopes[scope]) for scope in SCOPES},
-            CONF_ENABLE_DEBUG_ENTITIES: self._debug,
-        }
-
-    async def async_step_save(self, user_input=None) -> FlowResult:
-        """Validate against existing adapters and persist the options."""
-        self._load()
-        new_options = self._compose()
-        problems = check_options_feasibility(self.config_entry, new_options)
-        if problems and user_input is None:
-            # Some devices lack data the new options need. Warn, but let the
-            # user confirm (submit) to apply anyway, then reconfigure them.
+    async def _save(self, options: dict) -> FlowResult:
+        """Persist *options*, or warn first if a device is under-configured."""
+        problems = check_options_feasibility(self.config_entry, options)
+        if problems:
+            # Save anyway is allowed: the user confirms on the next form.
+            self._pending = options
             return self.async_show_form(
-                step_id="save",
+                step_id="confirm",
                 data_schema=vol.Schema({}),
                 errors={"base": "reconfigure_adapters_first"},
                 description_placeholders={
                     "adapters_needing_reconfigure": ", ".join(problems),
                 },
             )
-        return self.async_create_entry(title="", data=new_options)
+        return self.async_create_entry(title="", data=options)
+
+    async def async_step_confirm(self, user_input=None) -> FlowResult:
+        """Apply the pending selection after the under-configured warning."""
+        return self.async_create_entry(title="", data=self._pending)

--- a/custom_components/power_insight/translations/en.json
+++ b/custom_components/power_insight/translations/en.json
@@ -30,15 +30,14 @@
     "step": {
       "init": {
         "title": "Options",
-        "description": "Choose a section to configure which sensors to create. Each device type shows only the options it supports.\nChanges apply automatically — the integration reloads itself, so no Home Assistant restart is needed. Disabled sensors are hidden but keep their history and reappear when re-enabled.",
+        "description": "Choose a section to configure which sensors to create. Each device type shows only the options it supports, and your choices are saved when you submit a section.\nChanges apply automatically — the integration reloads itself, so no Home Assistant restart is needed. Disabled sensors are hidden but keep their history and reappear when re-enabled.",
         "menu_options": {
           "combined": "Whole-home (combined)",
           "grid": "Grid",
           "pv_system": "PV systems",
           "battery": "Batteries",
           "consumer": "Consumers",
-          "diagnostics": "Diagnostics",
-          "save": "Save and apply"
+          "diagnostics": "Diagnostics"
         }
       },
       "combined": {
@@ -152,9 +151,9 @@
           "debug_power_entities": "Expose power values used by the internal calculations as additional sensors. Useful for troubleshooting."
         }
       },
-      "save": {
-        "title": "Save and apply",
-        "description": "Some devices are missing data required by your selection. You can save anyway and reconfigure them afterwards, or go back to adjust your choices."
+      "confirm": {
+        "title": "Some devices need configuring",
+        "description": "Your selection needs data that one or more devices have not provided yet. Submit to save anyway, then reconfigure those devices."
       }
     },
     "error": {

--- a/docs/options-flow-redesign.md
+++ b/docs/options-flow-redesign.md
@@ -16,6 +16,8 @@ Refinements made during implementation (the code is the source of truth):
   cost savings**.
 - The grid gained **Import power** alongside Export power.
 - The options flow is a **menu** with one step per scope (no defaults/inherit).
+- Each section is **saved immediately on submit** (no separate "save" step);
+  an under-configured selection routes through a confirm step ("save anyway").
 
 This spec reorganises the integration's options so that *which sensors are
 created* is configured **per device type**, in human‑readable categories, from a

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -305,17 +305,16 @@ async def test_options_flow_shows_menu(hass: HomeAssistant) -> None:
     result = await hass.config_entries.options.async_init(entry.entry_id)
     assert result["type"] == FlowResultType.MENU
     assert result["step_id"] == "init"
-    # Combined + grid (present) + diagnostics + save; no pv/battery/consumer.
+    # Combined + grid (present) + diagnostics; no pv/battery/consumer, no save.
     assert "combined" in result["menu_options"]
     assert "grid" in result["menu_options"]
-    assert "save" in result["menu_options"]
+    assert "diagnostics" in result["menu_options"]
+    assert "save" not in result["menu_options"]
     assert "battery" not in result["menu_options"]
 
 
-async def test_options_flow_edits_grid_scope_and_saves(
-    hass: HomeAssistant,
-) -> None:
-    """Editing the grid scope then saving persists the per-scope selection."""
+async def test_options_flow_submit_saves_immediately(hass: HomeAssistant) -> None:
+    """Submitting a section persists straight away — no separate save step."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="My PowerInsight",
@@ -325,14 +324,43 @@ async def test_options_flow_edits_grid_scope_and_saves(
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
-    # Open the grid section from the menu.
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "combined"}
+    )
+    assert result["step_id"] == "combined"
+    # Only distribution sensors → no data requirements → saves directly.
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "cost_rates": [],
+            "cost_savings_rates": [],
+            "accumulated_costs": [],
+            "accumulated_cost_savings": [],
+            "distribution_power": True,
+            "distribution_ratios": False,
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.options["scopes"]["combined"] == ["enable_distribution_power"]
+
+
+async def test_options_flow_warns_then_saves_under_configured(
+    hass: HomeAssistant,
+) -> None:
+    """Enabling a cost rate with no price entity warns, then saves on confirm."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="My PowerInsight",
+        options=BASE_OPTIONS,
+        subentries_data=[make_grid_subentry_data()],
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={"next_step_id": "grid"}
     )
-    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "grid"
-
-    # Enable the grid cost rate; turn distribution off.
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
@@ -344,19 +372,12 @@ async def test_options_flow_edits_grid_scope_and_saves(
             "distribution_shares": False,
         },
     )
-    # Back at the menu; now save.
-    assert result["type"] == FlowResultType.MENU
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={"next_step_id": "save"}
-    )
-    # Grid has no price entity, so enabling a cost rate warns; confirm to apply.
+    # Grid has no price entity → confirm step (save anyway).
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "save"
+    assert result["step_id"] == "confirm"
     assert result["errors"]["base"] == "reconfigure_adapters_first"
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={}
     )
     assert result["type"] == FlowResultType.CREATE_ENTRY
-
     assert entry.options["scopes"]["grid"] == ["calculate_cost_rates"]
-    assert entry.options["schema"] == 2


### PR DESCRIPTION
Follow-up to #17 (the per-scope options redesign).

## Problem
In the new per-scope options flow, clicking **Submit** on a device section only
staged the change in memory; nothing was persisted until a separate **Save and
apply** step. Users won't understand that — Submit reads like it saves, and
closing the dialog beforehand silently discarded changes.

## Change
Each section now **saves immediately on Submit** via `async_create_entry`:

- The menu lists only the scopes + Diagnostics (the `save` entry is gone).
- Submitting a section persists that scope's selection straight away.
- A selection that needs data a device hasn't provided yet (e.g. a cost rate
  with no price entity on the grid) routes through a small **confirm** step, so
  the user can save anyway and reconfigure the device afterwards.

This also removes the earlier "staged but unsaved" trap, so the dialog's
header back arrow is enough for navigation.

Trade-off: because each Submit persists, the entry reloads after each edited
section rather than once at the end — a fast in-place reload for these option
changes.

## Tests
- menu no longer offers a `save` entry
- `test_options_flow_submit_saves_immediately` — a section with no data
  requirements saves directly on submit
- `test_options_flow_warns_then_saves_under_configured` — cost rate without a
  price entity warns, then saves on confirm

162 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019memJbURkLJkEMqsqUowQk)_