### PR TITLE
Keep options dialog open after submit; reload on each save

### DIFF
--- a/custom_components/power_insight/config_flow.py
+++ b/custom_components/power_insight/config_flow.py
@@ -1515,9 +1515,10 @@ class PowerInsightOptionsFlow(OptionsFlow):
     A menu offers the whole-home (combined) scope plus one section per
     configured device type, and a diagnostics section. Each section shows only
     the categories its scope supports and is **saved immediately on submit** —
-    there is no separate save step, so "Submit" always persists. When the
-    submitted selection needs data a device has not provided yet, a confirm
-    step lets the user save anyway and reconfigure the device afterwards.
+    submitting persists that scope and returns to the menu (reloading the entry
+    so the change takes effect), so the flow stays open to edit more sections.
+    "Done" closes the dialog. When a submitted selection needs data a device has
+    not provided yet, a confirm step lets the user save anyway.
     """
 
     def __init__(self) -> None:
@@ -1554,6 +1555,7 @@ class PowerInsightOptionsFlow(OptionsFlow):
                 SCOPE_COMBINED,
                 *self._present_device_scopes(),
                 "diagnostics",
+                "done",
             ],
         )
 
@@ -1621,8 +1623,25 @@ class PowerInsightOptionsFlow(OptionsFlow):
                     "adapters_needing_reconfigure": ", ".join(problems),
                 },
             )
-        return self.async_create_entry(title="", data=options)
+        return await self._persist(options)
+
+    async def _persist(self, options: dict) -> FlowResult:
+        """Write the options (triggering a reload) and return to the menu.
+
+        Persisting via ``async_update_entry`` rather than ending the flow with
+        ``async_create_entry`` keeps the options dialog open, so the user can
+        edit several sections in one sitting while each submit takes effect.
+        """
+        self.hass.config_entries.async_update_entry(
+            self.config_entry, options=options
+        )
+        self._pending = None
+        return await self.async_step_init()
 
     async def async_step_confirm(self, user_input=None) -> FlowResult:
         """Apply the pending selection after the under-configured warning."""
-        return self.async_create_entry(title="", data=self._pending)
+        return await self._persist(self._pending)
+
+    async def async_step_done(self, user_input=None) -> FlowResult:
+        """Close the options dialog (changes are already saved)."""
+        return self.async_create_entry(title="", data=self._current_options())

--- a/custom_components/power_insight/translations/en.json
+++ b/custom_components/power_insight/translations/en.json
@@ -37,7 +37,8 @@
           "pv_system": "PV systems",
           "battery": "Batteries",
           "consumer": "Consumers",
-          "diagnostics": "Diagnostics"
+          "diagnostics": "Diagnostics",
+          "done": "Done"
         }
       },
       "combined": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -309,12 +309,15 @@ async def test_options_flow_shows_menu(hass: HomeAssistant) -> None:
     assert "combined" in result["menu_options"]
     assert "grid" in result["menu_options"]
     assert "diagnostics" in result["menu_options"]
+    assert "done" in result["menu_options"]
     assert "save" not in result["menu_options"]
     assert "battery" not in result["menu_options"]
 
 
-async def test_options_flow_submit_saves_immediately(hass: HomeAssistant) -> None:
-    """Submitting a section persists straight away — no separate save step."""
+async def test_options_flow_submit_saves_and_returns_to_menu(
+    hass: HomeAssistant,
+) -> None:
+    """Submitting a section persists immediately and returns to the menu."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="My PowerInsight",
@@ -340,8 +343,16 @@ async def test_options_flow_submit_saves_immediately(hass: HomeAssistant) -> Non
             "distribution_ratios": False,
         },
     )
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    # Saved immediately, and the flow stays open on the menu.
+    assert result["type"] == FlowResultType.MENU
+    assert result["step_id"] == "init"
     assert entry.options["scopes"]["combined"] == ["enable_distribution_power"]
+
+    # "Done" closes the dialog.
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "done"}
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
 
 
 async def test_options_flow_warns_then_saves_under_configured(
@@ -379,5 +390,6 @@ async def test_options_flow_warns_then_saves_under_configured(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], user_input={}
     )
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    # Saved (anyway) and back at the menu.
+    assert result["type"] == FlowResultType.MENU
     assert entry.options["scopes"]["grid"] == ["calculate_cost_rates"]

--- a/tests/test_sensor_entities.py
+++ b/tests/test_sensor_entities.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -221,6 +222,49 @@ async def test_grid_owns_import_export_and_compensation_sensors(
     # Export compensation no longer exists at the combined/hub level.
     assert f"{entry.entry_id}_combined_export_compensation_rate" not in uids
     assert f"{entry.entry_id}_combined_total_export_compensation" not in uids
+
+
+async def test_options_submit_reloads_entry_live(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Submitting a section reloads the entry so the change takes effect, and
+    the flow stays open on the menu."""
+    hass.states.async_set(
+        "sensor.grid_power", "0", {"unit_of_measurement": "W"}
+    )
+    await setup_integration(hass, mock_config_entry)
+    ent_reg = er.async_get(hass)
+    uid = f"{mock_config_entry.entry_id}_combined_export_ratio"
+    entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, uid)
+    assert entity_id is not None
+    assert ent_reg.async_get(entity_id).disabled_by is None
+
+    result = await hass.config_entries.options.async_init(
+        mock_config_entry.entry_id
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "combined"}
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "cost_rates": [],
+            "cost_savings_rates": [],
+            "accumulated_costs": [],
+            "accumulated_cost_savings": [],
+            "distribution_power": True,
+            "distribution_ratios": False,  # drop ratios → export ratio disabled
+        },
+    )
+    # Flow stayed open on the menu.
+    assert result["type"] == FlowResultType.MENU
+    await hass.async_block_till_done()
+
+    # The submit reloaded the entry and applied the change.
+    assert (
+        ent_reg.async_get(entity_id).disabled_by
+        is er.RegistryEntryDisabler.INTEGRATION
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #18.

## Change
Submitting a section in the per-scope options flow now persists via
`async_update_entry` — which fires the update listener and **reloads the entry
so the change takes effect** — and returns to the menu, instead of closing the
dialog with `async_create_entry`.

Result: the options dialog stays open, so the user can edit several sections in
one sitting with each submit applying immediately. A **Done** menu entry closes
the dialog. The under-configured confirm path also saves-and-returns to the
menu.

## Tests
- `test_options_flow_submit_saves_and_returns_to_menu` — submit lands back on
  the menu with the change saved; Done closes the dialog.
- `test_options_submit_reloads_entry_live` — full setup, submit a section, and
  assert the entry actually reloaded (the dropped sensor was disabled) while the
  flow stayed on the menu.

163 passing.

Note: editing N sections triggers N reloads (one per submit); these are fast
in-place reloads for option changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019memJbURkLJkEMqsqUowQk)_