### PR TITLE
Options flow: one sectioned form with a single submit

### DIFF
--- a/custom_components/power_insight/config_flow.py
+++ b/custom_components/power_insight/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.config_entries import (
     SubentryFlowResult,
 )
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.data_entry_flow import FlowResult, section
 from homeassistant.helpers import issue_registry as ir, selector
 from homeassistant.const import CONF_NAME
 from homeassistant.util import slugify
@@ -1510,119 +1510,93 @@ class AdapterSubentryFlow(ConfigSubentryFlow):
 # ============================================================================
 
 class PowerInsightOptionsFlow(OptionsFlow):
-    """Per-scope options flow.
+    """Single-form options flow.
 
-    A menu offers the whole-home (combined) scope plus one section per
-    configured device type, and a diagnostics section. Each section shows only
-    the categories its scope supports and is **saved immediately on submit** —
-    there is no separate save step, so "Submit" always persists. When the
-    submitted selection needs data a device has not provided yet, a confirm
-    step lets the user save anyway and reconfigure the device afterwards.
+    Every option is shown on one screen, grouped into collapsible sections — the
+    whole-home (combined) scope, one section per configured device type, and a
+    diagnostics section — with a single Submit button. Each section offers only
+    the categories its scope supports. Submitting validates that the selection
+    does not require data a device has not provided yet (otherwise the form is
+    re-shown with an error), then saves everything in one reload.
     """
 
-    def __init__(self) -> None:
-        """Initialise the pending-confirm buffer."""
-        self._pending: dict | None = None
-
-    def _current_options(self) -> dict:
-        """Return a fresh, mutable copy of the stored options (v2 shape)."""
-        options = self.config_entry.options
-        stored = options.get("scopes", {})
-        return {
-            "schema": 2,
-            "scopes": {scope: list(stored.get(scope, [])) for scope in SCOPES},
-            CONF_ENABLE_DEBUG_ENTITIES: bool(
-                options.get(CONF_ENABLE_DEBUG_ENTITIES, False)
-            ),
-        }
-
-    def _present_device_scopes(self) -> list[str]:
-        """Return device-type scopes that have at least one subentry."""
+    def _shown_scopes(self) -> list[str]:
+        """Combined plus the device-type scopes that have a subentry."""
         types = {
             sub.data.get("adapter", {}).get("adapter_type")
             for sub in self.config_entry.subentries.values()
         }
-        return [t for t in ("grid", "pv_system", "battery", "consumer") if t in types]
+        return [SCOPE_COMBINED] + [
+            t for t in ("grid", "pv_system", "battery", "consumer") if t in types
+        ]
+
+    def _build_schema(
+        self, scopes: dict[str, set[str]], debug: bool
+    ) -> vol.Schema:
+        """Build the one-screen schema: a section per scope + diagnostics."""
+        fields: dict = {}
+        for scope in self._shown_scopes():
+            fields[vol.Required(scope)] = section(
+                build_scope_schema(scope, scopes.get(scope, set())),
+                {"collapsed": False},
+            )
+        fields[vol.Required("diagnostics")] = section(
+            vol.Schema({
+                vol.Required(
+                    CONF_ENABLE_DEBUG_ENTITIES, default=debug
+                ): BOOLEAN_SELECTOR,
+            }),
+            {"collapsed": True},
+        )
+        return vol.Schema(fields)
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Show the section menu."""
-        return self.async_show_menu(
-            step_id="init",
-            menu_options=[
-                SCOPE_COMBINED,
-                *self._present_device_scopes(),
-                "diagnostics",
-            ],
-        )
+        """Show all options on one sectioned form and save on submit."""
+        stored = self.config_entry.options.get("scopes", {})
 
-    async def _async_scope_step(
-        self, scope: str, user_input: dict[str, Any] | None
-    ) -> FlowResult:
-        """Render a scope's categories, saving the selection on submit."""
         if user_input is not None:
-            options = self._current_options()
-            options["scopes"][scope] = collect_scope_selection(scope, user_input)
-            return await self._save(options)
-        current = set(self.config_entry.options.get("scopes", {}).get(scope, []))
-        return self.async_show_form(
-            step_id=scope,
-            data_schema=build_scope_schema(scope, current),
-        )
-
-    async def async_step_combined(self, user_input=None) -> FlowResult:
-        """Edit the whole-home (combined) scope."""
-        return await self._async_scope_step(SCOPE_COMBINED, user_input)
-
-    async def async_step_grid(self, user_input=None) -> FlowResult:
-        """Edit the grid scope."""
-        return await self._async_scope_step("grid", user_input)
-
-    async def async_step_pv_system(self, user_input=None) -> FlowResult:
-        """Edit the PV-system scope."""
-        return await self._async_scope_step("pv_system", user_input)
-
-    async def async_step_battery(self, user_input=None) -> FlowResult:
-        """Edit the battery scope."""
-        return await self._async_scope_step("battery", user_input)
-
-    async def async_step_consumer(self, user_input=None) -> FlowResult:
-        """Edit the consumer scope."""
-        return await self._async_scope_step("consumer", user_input)
-
-    async def async_step_diagnostics(self, user_input=None) -> FlowResult:
-        """Edit the global diagnostics toggle, saving on submit."""
-        if user_input is not None:
-            options = self._current_options()
-            options[CONF_ENABLE_DEBUG_ENTITIES] = bool(
-                user_input.get(CONF_ENABLE_DEBUG_ENTITIES, False)
+            # Section fields arrive nested under their section key.
+            selected = {
+                scope: set(
+                    collect_scope_selection(scope, user_input.get(scope, {}))
+                )
+                for scope in self._shown_scopes()
+            }
+            debug = bool(
+                user_input.get("diagnostics", {}).get(
+                    CONF_ENABLE_DEBUG_ENTITIES, False
+                )
             )
-            return await self._save(options)
-        debug = bool(self.config_entry.options.get(CONF_ENABLE_DEBUG_ENTITIES, False))
-        return self.async_show_form(
-            step_id="diagnostics",
-            data_schema=vol.Schema({
-                vol.Required(CONF_ENABLE_DEBUG_ENTITIES, default=debug): BOOLEAN_SELECTOR,
-            }),
-        )
-
-    async def _save(self, options: dict) -> FlowResult:
-        """Persist *options*, or warn first if a device is under-configured."""
-        problems = check_options_feasibility(self.config_entry, options)
-        if problems:
-            # Save anyway is allowed: the user confirms on the next form.
-            self._pending = options
+            # Scopes whose device type is not present keep their stored value.
+            new_scopes = {
+                scope: sorted(selected[scope])
+                if scope in selected
+                else list(stored.get(scope, []))
+                for scope in SCOPES
+            }
+            new_options = {
+                "schema": 2,
+                "scopes": new_scopes,
+                CONF_ENABLE_DEBUG_ENTITIES: debug,
+            }
+            problems = check_options_feasibility(self.config_entry, new_options)
+            if not problems:
+                return self.async_create_entry(title="", data=new_options)
+            # Re-show the form (sticky) with a validation error.
             return self.async_show_form(
-                step_id="confirm",
-                data_schema=vol.Schema({}),
+                step_id="init",
+                data_schema=self._build_schema(selected, debug),
                 errors={"base": "reconfigure_adapters_first"},
                 description_placeholders={
                     "adapters_needing_reconfigure": ", ".join(problems),
                 },
             )
-        return self.async_create_entry(title="", data=options)
 
-    async def async_step_confirm(self, user_input=None) -> FlowResult:
-        """Apply the pending selection after the under-configured warning."""
-        return self.async_create_entry(title="", data=self._pending)
+        scopes = {scope: set(stored.get(scope, [])) for scope in self._shown_scopes()}
+        debug = bool(self.config_entry.options.get(CONF_ENABLE_DEBUG_ENTITIES, False))
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self._build_schema(scopes, debug),
+        )

--- a/custom_components/power_insight/translations/en.json
+++ b/custom_components/power_insight/translations/en.json
@@ -30,134 +30,119 @@
     "step": {
       "init": {
         "title": "Options",
-        "description": "Choose a section to configure which sensors to create. Each device type shows only the options it supports, and your choices are saved when you submit a section.\nChanges apply automatically — the integration reloads itself, so no Home Assistant restart is needed. Disabled sensors are hidden but keep their history and reappear when re-enabled.",
-        "menu_options": {
-          "combined": "Whole-home (combined)",
-          "grid": "Grid",
-          "pv_system": "PV systems",
-          "battery": "Batteries",
-          "consumer": "Consumers",
-          "diagnostics": "Diagnostics"
+        "description": "Choose which sensors to create. Each device type shows only the options it supports.\nChanges apply automatically — the integration reloads itself, so no Home Assistant restart is needed. Disabled sensors are hidden but keep their history and reappear when re-enabled.",
+        "sections": {
+          "combined": {
+            "name": "Whole-home (combined)",
+            "data": {
+              "distribution_power": "Power distribution (W)",
+              "cost_rates": "Cost rates (per hour)",
+              "cost_savings_rates": "Cost savings rates (per hour)",
+              "accumulated_costs": "Accumulated costs",
+              "accumulated_cost_savings": "Accumulated cost savings",
+              "distribution_ratios": "Power distribution ratios"
+            },
+            "data_description": {
+              "distribution_power": "Watt power-split sensors (import/export, self-consumption, charging, standby).",
+              "cost_rates": "Operating cost rate, and optionally its levelized variant.",
+              "cost_savings_rates": "Self-consumption cost savings rate, and optionally its levelized variant.",
+              "accumulated_costs": "Running totals of operating cost.",
+              "accumulated_cost_savings": "Running totals of cost savings.",
+              "distribution_ratios": "Percentage of a device's own power that is exported, self-consumed, charging or standby."
+            }
+          },
+          "grid": {
+            "name": "Grid",
+            "data": {
+              "distribution_power": "Power distribution (W)",
+              "cost_rates": "Cost rates (per hour)",
+              "accumulated_costs": "Accumulated costs",
+              "export_compensation": "Export compensation",
+              "distribution_ratios": "Power distribution ratios",
+              "distribution_shares": "Power distribution shares"
+            },
+            "data_description": {
+              "distribution_power": "Watt power-split sensors (import/export, self-consumption, charging, standby).",
+              "cost_rates": "Operating cost rate, and optionally its levelized variant.",
+              "accumulated_costs": "Running totals of operating cost.",
+              "export_compensation": "Compensation for energy fed to the grid: the rate and/or its running total.",
+              "distribution_ratios": "Percentage of a device's own power that is exported, self-consumed, charging or standby.",
+              "distribution_shares": "A device's share of the combined export / self-consumption."
+            }
+          },
+          "pv_system": {
+            "name": "PV systems",
+            "data": {
+              "distribution_power": "Power distribution (W)",
+              "cost_rates": "Cost rates (per hour)",
+              "cost_savings_rates": "Cost savings rates (per hour)",
+              "export_compensation": "Export compensation",
+              "accumulated_costs": "Accumulated costs",
+              "accumulated_cost_savings": "Accumulated cost savings",
+              "distribution_ratios": "Power distribution ratios",
+              "distribution_shares": "Power distribution shares"
+            },
+            "data_description": {
+              "distribution_power": "Watt power-split sensors (import/export, self-consumption, charging, standby).",
+              "cost_rates": "Operating cost rate, and optionally its levelized variant.",
+              "cost_savings_rates": "Self-consumption cost savings rate, and optionally its levelized variant.",
+              "export_compensation": "Compensation for energy fed to the grid: the rate and/or its running total.",
+              "accumulated_costs": "Running totals of operating cost.",
+              "accumulated_cost_savings": "Running totals of cost savings.",
+              "distribution_ratios": "Percentage of a device's own power that is exported, self-consumed, charging or standby.",
+              "distribution_shares": "A device's share of the combined export / self-consumption."
+            }
+          },
+          "battery": {
+            "name": "Batteries",
+            "data": {
+              "distribution_power": "Power distribution (W)",
+              "cost_rates": "Cost rates (per hour)",
+              "cost_savings_rates": "Cost savings rates (per hour)",
+              "export_compensation": "Export compensation",
+              "accumulated_costs": "Accumulated costs",
+              "accumulated_cost_savings": "Accumulated cost savings",
+              "distribution_ratios": "Power distribution ratios",
+              "distribution_shares": "Power distribution shares",
+              "charging_source_shares": "Charging source shares"
+            },
+            "data_description": {
+              "distribution_power": "Watt power-split sensors (import/export, self-consumption, charging, standby).",
+              "cost_rates": "Operating cost rate, and optionally its levelized variant.",
+              "cost_savings_rates": "Self-consumption cost savings rate, and optionally its levelized variant.",
+              "export_compensation": "Compensation for energy fed to the grid: the rate and/or its running total.",
+              "accumulated_costs": "Running totals of operating cost.",
+              "accumulated_cost_savings": "Running totals of cost savings.",
+              "distribution_ratios": "Percentage of a device's own power that is exported, self-consumed, charging or standby.",
+              "distribution_shares": "A device's share of the combined export / self-consumption.",
+              "charging_source_shares": "For each selected charge source, its share of the battery's charging."
+            }
+          },
+          "consumer": {
+            "name": "Consumers",
+            "data": {
+              "cost_rates": "Cost rates (per hour)",
+              "power_source_shares": "Power source shares"
+            },
+            "data_description": {
+              "cost_rates": "Operating cost rate, and optionally its levelized variant.",
+              "power_source_shares": "The share of this consumer's power coming from each source."
+            }
+          },
+          "diagnostics": {
+            "name": "Diagnostics",
+            "data": {
+              "debug_power_entities": "Enable debug power entities"
+            },
+            "data_description": {
+              "debug_power_entities": "Expose power values used by the internal calculations as additional sensors. Useful for troubleshooting."
+            }
+          }
         }
-      },
-      "combined": {
-        "title": "Whole-home sensors",
-        "description": "Sensors that aggregate your whole energy mix.",
-        "data": {
-          "distribution_power": "Power distribution (W)",
-          "cost_rates": "Cost rates (per hour)",
-          "cost_savings_rates": "Cost savings rates (per hour)",
-          "accumulated_costs": "Accumulated costs",
-          "accumulated_cost_savings": "Accumulated cost savings",
-          "distribution_ratios": "Power distribution ratios"
-        },
-        "data_description": {
-          "distribution_power": "Watt power-split sensors (import/export, self-consumption, charging, standby).",
-          "cost_rates": "Operating cost rate, and optionally its levelized variant.",
-          "cost_savings_rates": "Self-consumption cost savings rate, and optionally its levelized variant.",
-          "accumulated_costs": "Running totals of operating cost.",
-          "accumulated_cost_savings": "Running totals of cost savings.",
-          "distribution_ratios": "Percentage of a device's own power that is exported, self-consumed, charging or standby."
-        }
-      },
-      "grid": {
-        "title": "Grid sensors",
-        "description": "Import/export power, cost and export compensation at your grid connection.",
-        "data": {
-          "distribution_power": "Power distribution (W)",
-          "cost_rates": "Cost rates (per hour)",
-          "accumulated_costs": "Accumulated costs",
-          "export_compensation": "Export compensation",
-          "distribution_ratios": "Power distribution ratios",
-          "distribution_shares": "Power distribution shares"
-        },
-        "data_description": {
-          "distribution_power": "Watt power-split sensors (import/export, self-consumption, charging, standby).",
-          "cost_rates": "Operating cost rate, and optionally its levelized variant.",
-          "accumulated_costs": "Running totals of operating cost.",
-          "export_compensation": "Compensation for energy fed to the grid: the rate and/or its running total.",
-          "distribution_ratios": "Percentage of a device's own power that is exported, self-consumed, charging or standby.",
-          "distribution_shares": "A device's share of the combined export / self-consumption."
-        }
-      },
-      "pv_system": {
-        "title": "PV system sensors",
-        "description": "Applies to all PV system devices.",
-        "data": {
-          "distribution_power": "Power distribution (W)",
-          "cost_rates": "Cost rates (per hour)",
-          "cost_savings_rates": "Cost savings rates (per hour)",
-          "export_compensation": "Export compensation",
-          "accumulated_costs": "Accumulated costs",
-          "accumulated_cost_savings": "Accumulated cost savings",
-          "distribution_ratios": "Power distribution ratios",
-          "distribution_shares": "Power distribution shares"
-        },
-        "data_description": {
-          "distribution_power": "Watt power-split sensors (import/export, self-consumption, charging, standby).",
-          "cost_rates": "Operating cost rate, and optionally its levelized variant.",
-          "cost_savings_rates": "Self-consumption cost savings rate, and optionally its levelized variant.",
-          "export_compensation": "Compensation for energy fed to the grid: the rate and/or its running total.",
-          "accumulated_costs": "Running totals of operating cost.",
-          "accumulated_cost_savings": "Running totals of cost savings.",
-          "distribution_ratios": "Percentage of a device's own power that is exported, self-consumed, charging or standby.",
-          "distribution_shares": "A device's share of the combined export / self-consumption."
-        }
-      },
-      "battery": {
-        "title": "Battery sensors",
-        "description": "Applies to all battery devices.",
-        "data": {
-          "distribution_power": "Power distribution (W)",
-          "cost_rates": "Cost rates (per hour)",
-          "cost_savings_rates": "Cost savings rates (per hour)",
-          "export_compensation": "Export compensation",
-          "accumulated_costs": "Accumulated costs",
-          "accumulated_cost_savings": "Accumulated cost savings",
-          "distribution_ratios": "Power distribution ratios",
-          "distribution_shares": "Power distribution shares",
-          "charging_source_shares": "Charging source shares"
-        },
-        "data_description": {
-          "distribution_power": "Watt power-split sensors (import/export, self-consumption, charging, standby).",
-          "cost_rates": "Operating cost rate, and optionally its levelized variant.",
-          "cost_savings_rates": "Self-consumption cost savings rate, and optionally its levelized variant.",
-          "export_compensation": "Compensation for energy fed to the grid: the rate and/or its running total.",
-          "accumulated_costs": "Running totals of operating cost.",
-          "accumulated_cost_savings": "Running totals of cost savings.",
-          "distribution_ratios": "Percentage of a device's own power that is exported, self-consumed, charging or standby.",
-          "distribution_shares": "A device's share of the combined export / self-consumption.",
-          "charging_source_shares": "For each selected charge source, its share of the battery's charging."
-        }
-      },
-      "consumer": {
-        "title": "Consumer sensors",
-        "description": "Applies to all consumer devices.",
-        "data": {
-          "cost_rates": "Cost rates (per hour)",
-          "power_source_shares": "Power source shares"
-        },
-        "data_description": {
-          "cost_rates": "Operating cost rate, and optionally its levelized variant.",
-          "power_source_shares": "The share of this consumer's power coming from each source."
-        }
-      },
-      "diagnostics": {
-        "title": "Diagnostics",
-        "data": {
-          "debug_power_entities": "Enable debug power entities"
-        },
-        "data_description": {
-          "debug_power_entities": "Expose power values used by the internal calculations as additional sensors. Useful for troubleshooting."
-        }
-      },
-      "confirm": {
-        "title": "Some devices need configuring",
-        "description": "Your selection needs data that one or more devices have not provided yet. Submit to save anyway, then reconfigure those devices."
       }
     },
     "error": {
-      "reconfigure_adapters_first": "These devices are missing data required by your selection: {adapters_needing_reconfigure}. Save to apply anyway, then reconfigure them."
+      "reconfigure_adapters_first": "These devices are missing data required by your selection: {adapters_needing_reconfigure}. Reconfigure them, or deselect those options."
     }
   },
   "config_subentries": {

--- a/docs/options-flow-redesign.md
+++ b/docs/options-flow-redesign.md
@@ -312,24 +312,28 @@ disables/re‑enables based on the resolved "wanted" set.
 
 ## 8. Options flow (`config_flow.py`)
 
-Menu‑driven; accumulate into `self._data`; finish on an explicit Save.
+**Single form**, with one collapsible **section** per shown scope plus a
+diagnostics section, and one Submit button (HA `data_entry_flow.section`).
 
 ```
-async_step_init → async_show_menu:
-   • combined        (always)
-   • grid            (if grid subentry exists)
-   • pv_system       (if ≥1 PV)
-   • battery         (if ≥1 battery)
-   • consumer        (if ≥1 consumer)
-   • diagnostics     (always)
-   • save            → feasibility check → async_create_entry(data=self._data)
+async_step_init → async_show_form(step_id="init", schema = {
+   section("combined")     (always)
+   section("grid")         (if grid subentry exists)
+   section("pv_system")    (if ≥1 PV)
+   section("battery")      (if ≥1 battery)
+   section("consumer")     (if ≥1 consumer)
+   section("diagnostics")  (always; debug toggle)
+})
+on submit → feasibility check
+            → ok:       async_create_entry(data=new_options)   # one reload
+            → problems: re-show the form with errors["base"] = reconfigure_adapters_first
 ```
 
-Each `async_step_<scope>` renders the categories from
-`SCOPE_SUPPORTED_OPTIONS[scope]`, pre‑filled from the scope's stored list, and on
-submit writes that scope's list, then returns to the menu
-(`return await self.async_step_init()`). The three multi‑select selectors gain a
-small factory that filters their option list to a scope's supported leaves.
+Each section's schema is `build_scope_schema(scope, current)` (categories from
+`SCOPE_SUPPORTED_OPTIONS[scope]`, pre‑filled). Section fields arrive nested under
+the section key; `collect_scope_selection` turns each back into a leaf list.
+Scopes whose device type is absent keep their stored value. The under‑configured
+case **blocks** (re‑shows the form with an error) rather than saving.
 
 No "use default selection" toggle; each scope is edited directly and
 independently.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -292,8 +292,8 @@ async def test_subentry_pv_creates_subentry(hass: HomeAssistant) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_options_flow_shows_menu(hass: HomeAssistant) -> None:
-    """The options flow init step shows the per-scope section menu."""
+async def test_options_flow_shows_single_form(hass: HomeAssistant) -> None:
+    """The options flow is one form (sections), not a menu."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="My PowerInsight",
@@ -303,18 +303,16 @@ async def test_options_flow_shows_menu(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
-    # Combined + grid (present) + diagnostics; no pv/battery/consumer, no save.
-    assert "combined" in result["menu_options"]
-    assert "grid" in result["menu_options"]
-    assert "diagnostics" in result["menu_options"]
-    assert "save" not in result["menu_options"]
-    assert "battery" not in result["menu_options"]
+    # The schema carries a section per shown scope + diagnostics.
+    keys = {str(getattr(k, "schema", k)) for k in result["data_schema"].schema}
+    assert {"combined", "grid", "diagnostics"} <= keys
+    assert "battery" not in keys  # no battery subentry
 
 
-async def test_options_flow_submit_saves_immediately(hass: HomeAssistant) -> None:
-    """Submitting a section persists straight away — no separate save step."""
+async def test_options_flow_submit_saves_everything(hass: HomeAssistant) -> None:
+    """A single submit persists all sections at once."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="My PowerInsight",
@@ -324,30 +322,28 @@ async def test_options_flow_submit_saves_immediately(hass: HomeAssistant) -> Non
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={"next_step_id": "combined"}
-    )
-    assert result["step_id"] == "combined"
-    # Only distribution sensors → no data requirements → saves directly.
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "cost_rates": [],
-            "cost_savings_rates": [],
-            "accumulated_costs": [],
-            "accumulated_cost_savings": [],
-            "distribution_power": True,
-            "distribution_ratios": False,
+            "combined": {
+                "distribution_power": True,
+                "distribution_ratios": False,
+                "cost_rates": [],
+                "cost_savings_rates": [],
+                "accumulated_costs": [],
+                "accumulated_cost_savings": [],
+            },
+            "grid": {},  # keep current grid defaults
+            "diagnostics": {"debug_power_entities": True},
         },
     )
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert entry.options["scopes"]["combined"] == ["enable_distribution_power"]
+    assert entry.options["debug_power_entities"] is True
 
 
-async def test_options_flow_warns_then_saves_under_configured(
-    hass: HomeAssistant,
-) -> None:
-    """Enabling a cost rate with no price entity warns, then saves on confirm."""
+async def test_options_flow_blocks_under_configured(hass: HomeAssistant) -> None:
+    """Enabling a cost rate with no price entity re-shows the form with an error."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="My PowerInsight",
@@ -358,26 +354,21 @@ async def test_options_flow_warns_then_saves_under_configured(
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={"next_step_id": "grid"}
-    )
-    assert result["step_id"] == "grid"
-    result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            "cost_rates": ["calculate_cost_rates"],
-            "accumulated_costs": [],
-            "export_compensation": [],
-            "distribution_power": False,
-            "distribution_ratios": False,
-            "distribution_shares": False,
+            "combined": {},
+            "grid": {
+                "cost_rates": ["calculate_cost_rates"],
+                "distribution_power": False,
+                "distribution_ratios": False,
+                "distribution_shares": False,
+                "accumulated_costs": [],
+                "export_compensation": [],
+            },
+            "diagnostics": {"debug_power_entities": False},
         },
     )
-    # Grid has no price entity → confirm step (save anyway).
+    # Grid has no price entity → blocked, form re-shown with an error.
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "confirm"
+    assert result["step_id"] == "init"
     assert result["errors"]["base"] == "reconfigure_adapters_first"
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={}
-    )
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert entry.options["scopes"]["grid"] == ["calculate_cost_rates"]

--- a/tests/test_sensor_entities.py
+++ b/tests/test_sensor_entities.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -221,6 +222,48 @@ async def test_grid_owns_import_export_and_compensation_sensors(
     # Export compensation no longer exists at the combined/hub level.
     assert f"{entry.entry_id}_combined_export_compensation_rate" not in uids
     assert f"{entry.entry_id}_combined_total_export_compensation" not in uids
+
+
+async def test_options_form_submit_reloads_and_applies(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Submitting the single options form reloads the entry and applies it."""
+    hass.states.async_set(
+        "sensor.grid_power", "0", {"unit_of_measurement": "W"}
+    )
+    await setup_integration(hass, mock_config_entry)
+    ent_reg = er.async_get(hass)
+    uid = f"{mock_config_entry.entry_id}_combined_export_ratio"
+    entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, uid)
+    assert entity_id is not None
+    assert ent_reg.async_get(entity_id).disabled_by is None
+
+    result = await hass.config_entries.options.async_init(
+        mock_config_entry.entry_id
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "combined": {
+                "distribution_power": True,
+                "distribution_ratios": False,  # drop ratios → export ratio off
+                "cost_rates": [],
+                "cost_savings_rates": [],
+                "accumulated_costs": [],
+                "accumulated_cost_savings": [],
+            },
+            "grid": {},
+            "diagnostics": {"debug_power_entities": False},
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    await hass.async_block_till_done()
+
+    # The save reloaded the entry and applied the change.
+    assert (
+        ent_reg.async_get(entity_id).disabled_by
+        is er.RegistryEntryDisabler.INTEGRATION
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Replaces the per-scope **menu** options flow (from #17/#18) with a **single
form**: every option on one screen, grouped into collapsible **sections** and
saved with **one Submit** button.

## Why
The menu-of-sections model (navigate in → submit per section → back to menu)
was confusing. This puts all options in one view with one submit.

## How
Uses Home Assistant's `data_entry_flow.section` to render one collapsible group
per scope on a single `init` form:

- **Whole-home (combined)**, one section per configured device type
  (**Grid / PV systems / Batteries / Consumers**), and **Diagnostics**.
- Each section still offers only the categories its scope supports.
- A **single Submit** saves everything at once (one reload), instead of
  per-section saves and menu navigation.
- An under-configured selection (e.g. a cost rate with no price entity on the
  grid) **re-shows the form with an inline error** rather than saving.

Section fields arrive nested under their section key; `collect_scope_selection`
turns each back into a leaf list. Scopes whose device type isn't present keep
their stored value. The per-scope gating, disable/keep-history, and migration
are unchanged.

## Tests
- `test_options_flow_shows_single_form` — one form with a section per shown scope
- `test_options_flow_submit_saves_everything` — single submit persists all sections
- `test_options_flow_blocks_under_configured` — cost rate without a price entity
  re-shows the form with an error
- `test_options_form_submit_reloads_and_applies` — full setup, submit, and the
  entry reloads and applies the change

163 passing.

Note: supersedes the unmerged PR #19 (which kept the dialog open after submit) —
that approach is no longer needed with a single submit. #19 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019memJbURkLJkEMqsqUowQk)_