### PR TITLE
Improve the "no grid configured" repair message

### DIFF
--- a/custom_components/power_insight/translations/en.json
+++ b/custom_components/power_insight/translations/en.json
@@ -228,8 +228,8 @@
   },
   "issues": {
     "no_grid_configured": {
-      "title": "No grid configured for {entry_title}",
-      "description": "The Power Insight integration **{entry_title}** could not load because no grid connection has been configured. Open the integration and use the **Add device** button to add a grid connection."
+      "title": "Add a grid connection to {entry_title}",
+      "description": "**{entry_title}** has no grid connection yet, so Power Insight cannot calculate any costs, savings or power distribution — every device in your energy mix is measured against the grid.\n\nTo fix this:\n1. Open **Settings → Devices & services** and select the Power Insight integration.\n2. Click **Add device** and choose **Grid connection**.\n3. Select the sensor that reports your home's grid power (positive = import, negative = export).\n\nThis warning clears automatically once a grid connection is added."
     },
     "reconfigure_battery_adapters": {
       "title": "Battery {battery_name} needs reconfiguration",


### PR DESCRIPTION
## What

Reworks the `no_grid_configured` repair issue text shown when a Power Insight configuration has no grid connection.

### Before
> **No grid configured for Homegrid**
> The Power Insight integration **Homegrid** could not load because no grid connection has been configured. Open the integration and use the **Add device** button to add a grid connection.

### After
> **Add a grid connection to Homegrid**
> **Homegrid** has no grid connection yet, so Power Insight cannot calculate any costs, savings or power distribution — every device in your energy mix is measured against the grid.
>
> To fix this:
> 1. Open **Settings → Devices & services** and select the Power Insight integration.
> 2. Click **Add device** and choose **Grid connection**.
> 3. Select the sensor that reports your home's grid power (positive = import, negative = export).
>
> This warning clears automatically once a grid connection is added.

## Why

- **Accuracy:** the old message claimed the integration "could not load," but setup actually completes in a degraded state (`__init__.py` returns `True` and forwards platform setups) — it simply can't compute anything without a grid. The new wording reflects that.
- **Actionability:** numbered click-by-click steps, naming the exact menu and option, instead of a single sentence.
- **Context:** explains *why* a grid connection is required (every device is measured against the grid) and that the warning self-clears.

## Testing

- `en.json` validates as JSON.
- `uv run pytest tests/test_integration_setup.py` — 11 passed (issue key `no_grid_configured` unchanged, so the repair-issue tests still pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEMyEuFGwZALfB5yTBQh1d)_